### PR TITLE
Keep the chart name consistent with the previous'

### DIFF
--- a/docs/get_started/run_chaos_experiment.md
+++ b/docs/get_started/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-0.9.1/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-0.9.1/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-1.0.0/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-1.0.0/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-1.0.1/get_started/run_chaos_experiment.md
+++ b/versioned_docs/version-1.0.1/get_started/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 


### PR DESCRIPTION
If you install the helm chart with 
`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing`
 then the same chart name should be used for the upgrade