### PR TITLE
fix io chaos action

### DIFF
--- a/docs/chaos_experiments/io_chaos.md
+++ b/docs/chaos_experiments/io_chaos.md
@@ -61,17 +61,17 @@ kubectl apply -f examples/io-mixed-example.yaml
 
 IOChaos currently supports the following actions:
 
-- **delay**: IO delay action. You can specify the latency before the IO operation returns a result.
+- **latency**: IO latency action. You can specify the latency before the IO operation returns a result.
 - **fault**: IO fault action. In this mode, IO operations returns an error.
 - **attrOverride**: Override attributes of a file.
 
-### delay
+### latency
 
-If you are using the `delay` action, you can edit the specification as below:
+If you are using the `latency` action, you can edit the specification as below:
 
 ```yaml
 spec:
-  action: delay
+  action: latency
   delay: '1ms'
 ```
 

--- a/versioned_docs/version-1.0.2/chaos_experiments/io_chaos.md
+++ b/versioned_docs/version-1.0.2/chaos_experiments/io_chaos.md
@@ -61,17 +61,17 @@ kubectl apply -f examples/io-mixed-example.yaml
 
 IOChaos currently supports the following actions:
 
-- **delay**: IO delay action. You can specify the latency before the IO operation returns a result.
+- **latency**: IO latency action. You can specify the latency before the IO operation returns a result.
 - **fault**: IO fault action. In this mode, IO operations returns an error.
 - **attrOverride**: Override attributes of a file.
 
-### delay
+### latency
 
-If you are using the `delay` action, you can edit the specification as below:
+If you are using the `latency` action, you can edit the specification as below:
 
 ```yaml
 spec:
-  action: delay
+  action: latency
   delay: '1ms'
 ```
 


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Ref:
https://github.com/chaos-mesh/chaos-mesh/blob/8581cd063bc18b57d7135915401346b45eecef90/api/v1alpha1/podiochaos_types.go#L61-L73
```
// IoChaosType represents the type of an IoChaos Action
type IoChaosType string

const (
	// IoLatency represents injecting latency for io operation
	IoLatency IoChaosType = "latency"

	// IoFaults represents injecting faults for io operation
	IoFaults IoChaosType = "fault"

	// IoAttrOverride represents replacing attribution for io operation
	IoAttrOverride IoChaosType = "attrOverride"
)
```