### PR TITLE
add link checker from chaos-mesh repo

### DIFF
--- a/.github/workflows/checklink.yaml
+++ b/.github/workflows/checklink.yaml
@@ -1,0 +1,19 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        config-file: '.github/workflows/checklink_config.json'

--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": ["^https://github.com"]
+    },
+    {
+      "pattern": ["^https://www.linkedin.com"]
     }
   ]
 }

--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -7,6 +7,9 @@
       "pattern": ["^http://localhost"]
     },
     {
+      "pattern": ["^../"]
+    },
+    {
       "pattern": ["^https://github.com"]
     }
   ]

--- a/.github/workflows/checklink_config.json
+++ b/.github/workflows/checklink_config.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": ["^/img/"]
+    },
+    {
+      "pattern": ["^http://localhost"]
+    },
+    {
+      "pattern": ["^https://github.com"]
+    }
+  ]
+}

--- a/blog/2020-9-25-chaos-mesh-1.0-chaos-engineering-on-kubernetes-made-easier.md
+++ b/blog/2020-9-25-chaos-mesh-1.0-chaos-engineering-on-kubernetes-made-easier.md
@@ -56,7 +56,7 @@ When we conduct chaos experiments, it is vital that we keep strict control over 
 
 ## Try it out now
 
-You can quickly deploy Chaos Mesh in your Kubernetes environment through the `install.sh` script or the Helm tool. For specific installation steps, please refer to the [Chaos Mesh Getting Started](https://chaos-mesh.org/docs/get_started/installation) document. In addition, thanks to the [Katakoda interactive tutorial](https://chaos-mesh.org/interactiveTutorial), you can also quickly get your hands on Chaos Mesh without having to deploy it.
+You can quickly deploy Chaos Mesh in your Kubernetes environment through the `install.sh` script or the Helm tool. For specific installation steps, please refer to the [Chaos Mesh Getting Started](https://chaos-mesh.org/docs/user_guides/installation) document. In addition, thanks to the [Katakoda interactive tutorial](https://chaos-mesh.org/interactiveTutorial), you can also quickly get your hands on Chaos Mesh without having to deploy it.
 
 If you haven’t upgraded to 1.0 GA, please refer to the [1.0 Release Notes](https://github.com/chaos-mesh/chaos-mesh/releases/tag/v1.0.0) for the changes and upgrade guidelines.
 


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

The aim of adding a link checker to chaos-mesh/chaos-mesh is to check the dead links on the website. Since the website is moved to this repo, it would be better also move the link checker here.