### PR TITLE
docs: bypass validation for lower version of kubernetes

### DIFF
--- a/docs/user_guides/installation.md
+++ b/docs/user_guides/installation.md
@@ -84,6 +84,12 @@ To use Chaos Mesh, you must create the related custom resource type first.
   curl -sSL https://mirrors.chaos-mesh.org/latest/crd.yaml | kubectl apply -f -
 </PickVersion>
 
+For kuberentes < 1.15, `--validate=false` is needed to ignore the unexpected fields
+
+<PickVersion className="language-bash">
+  curl -sSL https://mirrors.chaos-mesh.org/latest/crd.yaml | kubectl apply --validate=false -f -
+</PickVersion>
+
 ### Step 3: Install Chaos Mesh
 
 > **Note:**


### PR DESCRIPTION
https://github.com/chaos-mesh/chaos-mesh/pull/1236 , we need to bypass the validation of kubernetes to add a field `preserveUnknownFields` on lower versions of kubernetes.

Signed-off-by: Yang Keao <keao.yang@yahoo.com>