### PR TITLE
chore: update minikube installation to helm v3

### DIFF
--- a/docs/get_started/get_started_on_minikube.md
+++ b/docs/get_started/get_started_on_minikube.md
@@ -27,11 +27,7 @@ Perform the following steps to set up the local Kubernetes environment:
 
 2. Install helm:
 
-   ```bash
-   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-   chmod 700 get_helm.sh
-   ./get_helm.sh
-   ```
+   Following helm installation steps: https://helm.sh/docs/intro/install
 
 ## Step 2: Install Chaos Mesh
 

--- a/docs/get_started/get_started_on_minikube.md
+++ b/docs/get_started/get_started_on_minikube.md
@@ -28,14 +28,9 @@ Perform the following steps to set up the local Kubernetes environment:
 2. Install helm:
 
    ```bash
-   curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
-   helm init
-   ```
-
-3. Check whether the helm tiller pod is running:
-
-   ```bash
-   kubectl -n kube-system get pods -l app=helm
+   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+   chmod 700 get_helm.sh
+   ./get_helm.sh
    ```
 
 ## Step 2: Install Chaos Mesh

--- a/versioned_docs/version-1.0.2/get_started/get_started_on_minikube.md
+++ b/versioned_docs/version-1.0.2/get_started/get_started_on_minikube.md
@@ -27,11 +27,7 @@ Perform the following steps to set up the local Kubernetes environment:
 
 2. Install helm:
 
-   ```bash
-   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-   chmod 700 get_helm.sh
-   ./get_helm.sh
-   ```
+   Following helm installation steps: https://helm.sh/docs/intro/install
 
 ## Step 2: Install Chaos Mesh
 

--- a/versioned_docs/version-1.0.2/get_started/get_started_on_minikube.md
+++ b/versioned_docs/version-1.0.2/get_started/get_started_on_minikube.md
@@ -28,14 +28,9 @@ Perform the following steps to set up the local Kubernetes environment:
 2. Install helm:
 
    ```bash
-   curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
-   helm init
-   ```
-
-3. Check whether the helm tiller pod is running:
-
-   ```bash
-   kubectl -n kube-system get pods -l app=helm
+   curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+   chmod 700 get_helm.sh
+   ./get_helm.sh
    ```
 
 ## Step 2: Install Chaos Mesh


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Following the official installation step on [release installation suggestion](https://github.com/helm/helm/releases/tag/v3.4.1) and [doc installation steps](https://helm.sh/docs/intro/install/#from-script), update helm installation from v2 to v3.