### PR TITLE
Remove "?"

### DIFF
--- a/blog/2021-01-08-how-to-simulate-io-faults-at-runtime.md
+++ b/blog/2021-01-08-how-to-simulate-io-faults-at-runtime.md
@@ -1,6 +1,6 @@
 ---
 slug: /how-to-simulate-io-faults-at-runtime
-title: 'How to Simulate I/O Faults at Runtime?'
+title: 'How to Simulate I/O Faults at Runtime'
 author: Keao Yang
 author_title: Maintainer of Chaos Mesh
 author_url: https://github.com/YangKeao


### PR DESCRIPTION
"How to XXX" is not a question, so we must remove the question mark. We already deleted "?" in the blog post on the PingCAP website.