### PR TITLE
remove size parameter of stress chaos

### DIFF
--- a/docs/chaos_experiments/stress_chaos.md
+++ b/docs/chaos_experiments/stress_chaos.md
@@ -23,7 +23,6 @@ A StressChaos shares common configurations like other chaos, such as how to sele
      | Option    | Type    | Required | Description                                                                                                                                                                                          |
      | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
      | `workers` | Integer | True     | Specifies concurrent stressing instance.                                                                                                                                                             |
-     | `size`    | String  | False    | Specifies memory size consumed per worker, default is the total available memory. One can also specify the size as _%_ of total available memory or in units of _B, KB/KiB, MB/MiB, GB/GiB, TB/TiB_. |
 
   2. `cpu`
 

--- a/versioned_docs/version-1.0.3/chaos_experiments/stress_chaos.md
+++ b/versioned_docs/version-1.0.3/chaos_experiments/stress_chaos.md
@@ -23,7 +23,6 @@ A StressChaos shares common configurations like other chaos, such as how to sele
      | Option    | Type    | Required | Description                                                                                                                                                                                          |
      | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
      | `workers` | Integer | True     | Specifies concurrent stressing instance.                                                                                                                                                             |
-     | `size`    | String  | False    | Specifies memory size consumed per worker, default is the total available memory. One can also specify the size as _%_ of total available memory or in units of _B, KB/KiB, MB/MiB, GB/GiB, TB/TiB_. |
 
   2. `cpu`
 

--- a/versioned_docs/version-1.1.0/chaos_experiments/stress_chaos.md
+++ b/versioned_docs/version-1.1.0/chaos_experiments/stress_chaos.md
@@ -23,7 +23,6 @@ A StressChaos shares common configurations like other chaos, such as how to sele
      | Option    | Type    | Required | Description                                                                                                                                                                                          |
      | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
      | `workers` | Integer | True     | Specifies concurrent stressing instance.                                                                                                                                                             |
-     | `size`    | String  | False    | Specifies memory size consumed per worker, default is the total available memory. One can also specify the size as _%_ of total available memory or in units of _B, KB/KiB, MB/MiB, GB/GiB, TB/TiB_. |
 
   2. `cpu`
 


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

The size parameter of a memory stress chaos has been removed several months ago.