### PR TITLE
Fix documentation typos, broken links and formatting

### DIFF
--- a/blog/2020-01-15-chaos-mesh-your-chaos-engineering-solution.md
+++ b/blog/2020-01-15-chaos-mesh-your-chaos-engineering-solution.md
@@ -31,7 +31,7 @@ Here is an example of how we use Chaos Mesh to locate a TiDB system bug. In this
 
 ![Chaos Mesh discovers downtime recovery exceptions in TiKV](/img/chaos-mesh-discovers-downtime-recovery-exceptions-in-tikv.png)
 
-<div class="caption-center"> Chaos Mesh discovers downtime recovery exceptions in TiKV </div>
+<div class="caption-center"> Chaos Mesh discovers downtime recovery exceptions in TiKV</div>
 
 As you can see from the dashboard:
 
@@ -121,7 +121,7 @@ With the CRD design settled, let's look at the big picture on how Chaos Mesh wor
 
 - **chaos-daemon**
 
-  Runs as a privileged daemonset that can operate network devices on the node and Cgroup.
+  Runs as a privileged DaemonSet that can operate network devices on the node and Cgroup.
 
 - **sidecar**
 

--- a/docs/configure-enabled-namespace.md
+++ b/docs/configure-enabled-namespace.md
@@ -7,7 +7,7 @@ This chapter walks you through how to configure Chaos experiments to only take e
 
 ## Control the scope where the Chaos experiment takes effect
 
-Chaos Mesh offers two ways to control the scope of the Chaos experiment to take effect：
+Chaos Mesh offers two ways to control the scope of the Chaos experiment to take effect:
 
 - To configure Chaos experiments to only take effect in the specified namespace, you need to enable the FilterNamespace feature (which is off by default). This feature takes effect on a global scope. After this feature is enabled, you can add annotations to the namespace in which Chaos experiments are allowed to take effect. Other namespaces without annotations are protected against fault injection.
 - To specify the scope for a single Chaos experiment to take effect, refer to [Define the scope of a Chaos experiment](define-chaos-experiment-scope.md).

--- a/docs/simulate-heavy-stress-in-physical-nodes.md
+++ b/docs/simulate-heavy-stress-in-physical-nodes.md
@@ -9,7 +9,7 @@ This document describes how to use Chaosd to simulate stress scenarios. This fea
 
 This section describes how to create stress experiments in command-line mode.
 
-Before creating stress experiments, you can run the following command to view the stress experiment types supported by Chaosd：
+Before creating stress experiments, you can run the following command to view the stress experiment types supported by Chaosd:
 
 ```bash
 chaosd attack stress --help
@@ -68,7 +68,7 @@ Global Flags:
 
 #### Configuration description of simulating CPU stress
 
-| Configuration item | Abbreviation | Descpription                                                                                           | Value                                    |
+| Configuration item | Abbreviation | Description                                                                                           | Value                                    |
 | :----------------- | :----------- | :----------------------------------------------------------------------------------------------------- | :--------------------------------------- |
 | load               | l            | Specifies the percentage of CPU load per CPU worker. 0 means no CPU load, and 100 means full CPU load. | int; range: 0 to 100; default value: 10. |
 | workers            | w            | Specifies the number of workers used to create CPU stress.                                             | int; default value: 1.                   |
@@ -138,7 +138,7 @@ The result is as follows:
 Attack stress mem successfully, uid: c2bff2f5-3aac-4ace-b7a6-322946ae6f13
 ```
 
-When running the experiment, you need to save the uid information of the experiment. When a stress simulation is not needed, you can use `recover` to terminate the uid-related experiment:：
+When running the experiment, you need to save the uid information of the experiment. When a stress simulation is not needed, you can use `recover` to terminate the uid-related experiment::
 
 ```bash
 chaosd recover c2bff2f5-3aac-4ace-b7a6-322946ae6f13

--- a/docs/simulate-heavy-stress-on-kubernetes.md
+++ b/docs/simulate-heavy-stress-on-kubernetes.md
@@ -5,7 +5,7 @@ sidebar_label: Simulate Stress Scenarios
 
 ## StressChaos Introduction
 
-Chaos Mesh provides StresChaos experiments to simulate stress scenarios inside containers. This document describes how to create StressChaos experiments and how to prepare the corresponding configuration file.
+Chaos Mesh provides StressChaos experiments to simulate stress scenarios inside containers. This document describes how to create StressChaos experiments and how to prepare the corresponding configuration file.
 
 You can create experiments using either Chaos Dashboard or the YAML configuration files.
 
@@ -84,7 +84,7 @@ The fields in the YAML configuration file are described in the following table:
 
 ##### CPUStressor
 
-| Parameter | Type | Descpription                                                                           | Default value | Required | Example |
+| Parameter | Type | Description                                                                           | Default value | Required | Example |
 | --------- | ---- | -------------------------------------------------------------------------------------- | ------------- | -------- | ------- |
 | workers   | int  | Specifies the number of threads that apply memory stress                               |               | Yes      | `1`     |
 | load      | int  | Specifies the percentage of CPU occupied0 means sleep and no load; 100 means full load |               | No       | `50`    |

--- a/docs/simulate-http-chaos-on-kubernetes.md
+++ b/docs/simulate-http-chaos-on-kubernetes.md
@@ -9,10 +9,10 @@ This document describes how to simulate HTTP faults by creating HTTPChaos experi
 
 HTTPChaos is a fault type provided by Chaos Mesh. By creating HTTPChaos experiments, you can simulate the fault scenarios of the HTTP server during the HTTP request and response processing. Currently, HTTPChaos supports simulating the following fault types:
 
-- `abort`: interrupts server connection.
-- `delay`: injects latency into the target process.
-- `replace`: replaces part of content in HTTP request or response messages.
-- `patch`: adds additional content to HTTP request or response messages.
+- `abort`: interrupts server connection
+- `delay`: injects latency into the target process
+- `replace`: replaces part of content in HTTP request or response messages
+- `patch`: adds additional content to HTTP request or response messages
 
 HTTPChaos supports combinations of different fault types. If you have configured multiple HTTP fault types at the same time when creating HTTPChaos experiments, the order set to inject the faults when the experiments start running is `abort` -> `delay` -> `replace` -> `patch`. When the `abort` fault cause short circuits, the connection will be directly interrupted.
 
@@ -28,11 +28,11 @@ Before injecting the faults supported by HTTPChaos, note the followings:
 
 ## Create experiments
 
-Currently, Chaos Mesh only supports using YAML configuration files to create HTTPChaos experiments. In the YAML files, you can simulate either one HTTP fault type or a comination of different HTTP fault types.
+Currently, Chaos Mesh only supports using YAML configuration files to create HTTPChaos experiments. In the YAML files, you can simulate either one HTTP fault type or a combination of different HTTP fault types.
 
 ### Example of `abort`
 
-1. Write the experimental configuration to the `http-abort-failure.yaml` file as the example below：
+1. Write the experimental configuration to the `http-abort-failure.yaml` file as the example below:
 
 ```yaml
 apiVersion: chaos-mesh.org/v1alpha1
@@ -64,7 +64,7 @@ kubectl apply -f ./http-abort-failure.yaml
 
 ### Example of fault combinations
 
-1. Write the experimental configuration to `http-failure.yaml` file as the example below：
+1. Write the experimental configuration to `http-failure.yaml` file as the example below:
 
 ```yaml
 apiVersion: chaos-mesh.org/v1alpha1
@@ -108,9 +108,9 @@ kubectl apply -f ./http-failure.yaml
 
 ### Description for common fields
 
-Common fields are meaningful when the `target` of fault injuection is `Request` or `Response`.
+Common fields are meaningful when the `target` of fault injection is `Request` or `Response`.
 
-| Parameter        | Type              | Descpription                                                                                                                                                                                                                                                                                                                                                                | Default value                             | Required | Example                        |
+| Parameter        | Type              | Description                                                                                                                                                                                                                                                                                                                                                                | Default value                             | Required | Example                        |
 | ---------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------- | ------------------------------ |
 | mode             | string            | Specifies the mode of the experiment. The mode options include `one` (selecting a random pod), `all` (selecting all eligible pods), `fixed` (selecting a specified number of eligible pods), `fixed-percent` (selecting a specified percentage of Pods from the eligible pods), and `random-max-percent` (selecting the maximum percentage of Pods from the eligible pods). |                                           | yes      | one                            |
 | value            | string            | Provides parameters for the `mode` configuration depending on the value of `mode`.                                                                                                                                                                                                                                                                                          |                                           | no       | 2                              |
@@ -138,9 +138,9 @@ The `Request` field is a meaningful when the `target` set to `Request` during th
 | Parameter        | Type              | Description                                                         | Default value | Required | Example      |
 | ---------------- | ----------------- | ------------------------------------------------------------------- | ------------- | -------- | ------------ |
 | replace.path     | string            | Specifies the URI path used to replace content.                     |               | no       | /api/v2/     |
-| replace.method`  | string            | Specifies the replaced content of the HTTP request method.          |               | no       | DELETE       |
-| replace.queries` | map[string]string | Specifies the replaced key pair of the URI query.                   |               | no       | foo: bar     |
-| patch.queries`   | [][]string        | Specifies the attached key pair of the URI query with patch faults. |               | no       | - [foo, bar] |
+| replace.method   | string            | Specifies the replaced content of the HTTP request method.          |               | no       | DELETE       |
+| replace.queries  | map[string]string | Specifies the replaced key pair of the URI query.                   |               | no       | foo: bar     |
+| patch.queries    | [][]string        | Specifies the attached key pair of the URI query with patch faults. |               | no       | - [foo, bar] |
 
 #### `Respond`-related fields
 

--- a/docs/simulate-io-chaos-on-kubernetes.md
+++ b/docs/simulate-io-chaos-on-kubernetes.md
@@ -9,12 +9,12 @@ This document describes how to create IOChaos experiments in Chaos Mesh.
 
 IOChaos is a type of fault in Chaos Mesh. By creating an IOChaos experiment, you can simulate a scenario of file system fault. Currently, IOChaos supports the following fault types:
 
-- latency: delays file system calls
-- fault: returns an error for filesystem calls
-- attrOverride: modifies file properties
-- mistake: makes the file read or write a wrong value
+- `latency`: delays file system calls
+- `fault`: returns an error for filesystem calls
+- `attrOverride`: modifies file properties
+- `mistake`: makes the file read or write a wrong value
 
-For specific features, refer to [Create experiments using the YAML files](#create-experiments-using-the-yaml-file).
+For specific features, refer to [Create experiments using the YAML files](#create-experiments-using-the-yaml-files).
 
 ## Notes
 
@@ -141,20 +141,20 @@ kubectl apply -f ./io-attr.yaml
 ```yaml
 apiVersion: chaos-mesh. rg/v1alpha1
 ind: IOChaos
-metaada:
+metadata:
   name: io-mistake-example
   namespace: chaos-testing
 special:
   action: mistake
   mode: one
   selector:
-    labelselectors:
+    labelSelectors:
       app: etcd
   volumePath: /var/run/etcd
   path: /var/run/etcd/**/*
   mistake:
     filling: zero
-    maxOccarences: 1
+    maxOccurrences: 1
     maxLength: 10
   methods:
     - READ

--- a/docs/simulate-jvm-application-chaos.md
+++ b/docs/simulate-jvm-application-chaos.md
@@ -87,7 +87,7 @@ Build application deployment:
 kubectl apply -f app.yaml
 ```
 
-Execute `kubectl -n app get pods`, and then you can find `1` Pod with a name like `springboot-jvmchaos-demo-777d94c5b9-7t7l2` under the namespace `app`. Wait for `READY` changes to `1/1` and then execute the following comands:
+Execute `kubectl -n app get pods`, and then you can find `1` Pod with a name like `springboot-jvmchaos-demo-777d94c5b9-7t7l2` under the namespace `app`. Wait for `READY` changes to `1/1` and then execute the following commands:
 
 ```shell
 kubectl -n app get pods

--- a/docs/simulate-network-chaos-in-physical-nodes.md
+++ b/docs/simulate-network-chaos-in-physical-nodes.md
@@ -75,7 +75,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -119,7 +119,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -128,8 +128,8 @@ The related configuration items are described as follows：
 | egress-port        | e            | The egress traffic which only impact specific destination ports. It can only be configured when the protocol is TCP or UDP. | String. You need to use a ',' to separate the specific port or to indicate the range of the port, such as "80,8001:8010". |
 | hostname           | H            | The host name impacted by traffic.                                                                                          | String, such as "chaos-mesh.org".                                                                                         |
 | ip                 | i            | The IP address impacted by egress traffic.                                                                                  | String, such as "123.123.123.123".                                                                                        |
-| jitter             | j            | Range of the length of network delay time.                                                                                  | String. The time units can be：ns, us (µs), ms, s, m, h, such as "1ms".                                                   |
-| latency            | l            | Length of network delay time.                                                                                               | String. The time units can be：ns, us (μs), ms, s, m, h, such as "1ms".                                                   |
+| jitter             | j            | Range of the length of network delay time.                                                                                  | String. The time units can be: ns, us (µs), ms, s, m, h, such as "1ms".                                                   |
+| latency            | l            | Length of network delay time.                                                                                               | String. The time units can be: ns, us (μs), ms, s, m, h, such as "1ms".                                                   |
 | protocol           | p            | The IP protocol impacted by traffic.                                                                                        | String. It supports the following protocol types: tcp, udp, icmp, all (all network protocols).                            |
 | source-port        | s            | The egress traffic that only impacts specified source ports. It can only be configured when the protocol is TCP or UDP.     | String. You need to use a ',' to separate the specific port or to indicate the range of the port, such as "80,8001:8010". |
 
@@ -164,7 +164,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                  | Value                                                                                                                     |
 | :----------------- | :----------- | :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -208,9 +208,9 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
-| Configuration item | Abbreviation | Descpription                                                                                                                 | Value                                                                                                                     |
+| Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
 | correlation        | c            | The correlation between the percentage of the current network loss and the previous one.                                     | Int. It is a percentage which range is 0 to 100 (10 is 10%) (default "0").                                                |
 | device             | d            | Name of the impacted network interface card.                                                                                 | String, such as “eth0”. The value is required.                                                                            |
@@ -223,7 +223,7 @@ The related configuration items are described as follows：
 
 ### Examples
 
-Simulate network corruption：
+Simulate network corruption:
 
 ```bash
 chaosd attack network corrupt -d eth0 -i 172.16.4.4 --percent 50
@@ -235,7 +235,7 @@ The output is as follows:
 Attack network successfully, uid: 4eab1e62-8d60-45cb-ac85-3c17b8ac4825
 ```
 
-Simulate network latency：
+Simulate network latency:
 
 ```bash
 chaosd attack network delay -d eth0 -i 172.16.4.4 -l 10ms
@@ -247,7 +247,7 @@ The output is as follows:
 Attack network successfully, uid: 4b23a0b5-e193-4b27-90a7-3e04235f32ab
 ```
 
-Simulate network duplication：
+Simulate network duplication:
 
 ```bash
 chaosd attack network duplicate -d eth0 -i 172.16.4.4 --percent 50
@@ -259,7 +259,7 @@ The output is as follows:
 Attack network successfully, uid: 7bcb74ee-9101-4ae4-82f0-e44c8a7f113c
 ```
 
-Simulate network loss：
+Simulate network loss:
 
 ```bash
 chaosd attack network loss -d eth0 -i 172.16.4.4 --percent 50
@@ -271,7 +271,7 @@ The output is as follows:
 Attack network successfully, uid: 1e818adf-3942-4de4-949b-c8499f120265
 ```
 
-When running the experiments, remember to save the uid of the experiments. To end a network fault simulation, use `recover`：
+When running the experiments, remember to save the uid of the experiments. To end a network fault simulation, use `recover`:
 
 ```bash
 chaosd recover 1e818adf-3942-4de4-949b-c8499f120265

--- a/docs/simulate-network-chaos-on-kubernetes.md
+++ b/docs/simulate-network-chaos-on-kubernetes.md
@@ -9,7 +9,7 @@ This document describes how to simulate network faults using NetworkChaos in Cha
 
 NetworkChaos is a fault type in Chaos Mesh. By creating a NetworkChaos experiment, you can simulate a network fault scenario for a cluster. Currently, NetworkChaos supports the following fault types:
 
-- **Partition**：network disconnection and partition.
+- **Partition**: network disconnection and partition.
 - **Net Emulation**: poor network conditions, such as high delays, high packet loss rate, packet reordering, and so on.
 - **Bandwidth**: limit the communication bandwidth between nodes.
 
@@ -63,7 +63,7 @@ Before creating NetworkChaos experiments, ensure the following:
        jitter: '0ms'
    ```
 
-This configuration causes a latency of 10 milliseconds in the network connections of the target Pods. In addition to latency injection, Chaos Mesh supports packet loss and packet reordering injection. For details, see [field description](#字段说明).
+This configuration causes a latency of 10 milliseconds in the network connections of the target Pods. In addition to latency injection, Chaos Mesh supports packet loss and packet reordering injection. For details, see [field description](#field-description).
 
 2. After the configuration file is prepared, use `kubectl` to create an experiment:
 
@@ -197,7 +197,7 @@ Setting `action` to `reorder` means simulating network packet reordering fault. 
 
 #### loss
 
-Setting `action` to `loss` means simualting packet loss fault. You can also configure the following parameters.
+Setting `action` to `loss` means simulating packet loss fault. You can also configure the following parameters.
 
 | Parameter   | Type   | Description                                                                                                  | Default value | Required | Example |
 | ----------- | ------ | ------------------------------------------------------------------------------------------------------------ | ------------- | -------- | ------- |

--- a/docs/simulate-pod-chaos-on-kubernetes.md
+++ b/docs/simulate-pod-chaos-on-kubernetes.md
@@ -9,13 +9,13 @@ This document describes how to use Chaos Mesh to inject faults into Kubernetes P
 
 PodChaos is a fault type in Chaos Mesh. By creating a PodChaos experiment, you can simulate fault scenarios of the specified Pods or containers. Currently, PodChaos supports the following fault types:
 
-- Pod Failure: injects fault into a specified Pod to make the Pod unavailable for a period of time.
-- Pod Kill: kills a specified Pod.To ensure that the Pod can be successfully restarted, you need to configure ReplicaSet or similar mechanisms.
-- Container Kill: kills the specified container in the target Pod.
+- **Pod Failure**: injects fault into a specified Pod to make the Pod unavailable for a period of time.
+- **Pod Kill**: kills a specified Pod.To ensure that the Pod can be successfully restarted, you need to configure ReplicaSet or similar mechanisms.
+- **Container Kill**: kills the specified container in the target Pod.
 
 ## Usage restrictions
 
-Currently, Chaos Mesh only supports fault injection to certain types of Pod, such as Deployment, Statefulset, and Daemonset. Chaos Mesh does not support injecting faults into an independent Pod. An independent Pod means a Pod that is not bound to ReplicaSet or Deployment Pod.
+Currently, Chaos Mesh only supports fault injection to certain types of Pod, such as Deployment, StatefulSet, and DaemonSet. Chaos Mesh does not support injecting faults into an independent Pod. An independent Pod means a Pod that is not bound to ReplicaSet or Deployment Pod.
 
 ## Notes
 

--- a/docs/simulate-process-chaos-in-physical-nodes.md
+++ b/docs/simulate-process-chaos-in-physical-nodes.md
@@ -3,7 +3,7 @@ title: Simulate Process Faults
 sidebar_label: Simulate Process Faults
 ---
 
-This document describes how to use Chaosd to simulate process faults. The process faults use the Golang interface of the kill command to simulate the scenarios that the process is killed or stoped. You can create experiments either in command-line mode or service mode.
+This document describes how to use Chaosd to simulate process faults. The process faults use the Golang interface of the kill command to simulate the scenarios that the process is killed or stopped. You can create experiments either in command-line mode or service mode.
 
 ## Create experiments in command-line mode
 
@@ -13,7 +13,7 @@ Before creating an experiment, you can run the following command to see the proc
 chaosd attack process -h
 ```
 
-The output is as follows：
+The output is as follows:
 
 ```bash
 Process attack related commands
@@ -44,7 +44,7 @@ Currently, Chaosd supports simulating that a process is killed or stopped.
 chaosd attack process kill -h
 ```
 
-The output is as follows：
+The output is as follows:
 
 ```bash
 kill process, default signal 9
@@ -63,7 +63,7 @@ Global Flags:
 
 #### Configuration description of simulating a process being killed
 
-| Configuration item | Abbreviation | Descpription                                                  | Value                                                                                     |
+| Configuration item | Abbreviation | Description                                                  | Value                                                                                     |
 | :----------------- | :----------- | :------------------------------------------------------------ | :---------------------------------------------------------------------------------------- |
 | process            | p            | The name or identifier of the process that needs to be killed | string; the default value is "".                                                          |
 | signal             | s            | The provided value of the process signal                      | int; the default value is 9. Currently, only SIGKILL, SIGTERM, and SIGSTOP are supported. |

--- a/versioned_docs/version-2.0.0/configure-enabled-namespace.md
+++ b/versioned_docs/version-2.0.0/configure-enabled-namespace.md
@@ -7,7 +7,7 @@ This chapter walks you through how to configure Chaos experiments to only take e
 
 ## Control the scope where the Chaos experiment takes effect
 
-Chaos Mesh offers two ways to control the scope of the Chaos experiment to take effect：
+Chaos Mesh offers two ways to control the scope of the Chaos experiment to take effect:
 
 - To configure Chaos experiments to only take effect in the specified namespace, you need to enable the FilterNamespace feature (which is off by default). This feature takes effect on a global scope. After this feature is enabled, you can add annotations to the namespace in which Chaos experiments are allowed to take effect. Other namespaces without annotations are protected against fault injection.
 - To specify the scope for a single Chaos experiment to take effect, refer to [Define the scope of a Chaos experiment](define-chaos-experiment-scope.md).

--- a/versioned_docs/version-2.0.0/simulate-disk-pressure-in-physical-nodes.md
+++ b/versioned_docs/version-2.0.0/simulate-disk-pressure-in-physical-nodes.md
@@ -58,7 +58,7 @@ Flags:
   -h, --help                help for read
   -p, --path string         'path' specifies the location to read data.If path not provided, payload will read from disk mount on "/"
   -n, --process-num uint8   'process-num' specifies the number of process work on reading , default 1, only 1-255 is valid value (default 1)
-  -s, --size string         'size' specifies how many units of data will read from the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTESexample : 1M | 512kB
+  -s, --size string         'size' specifies how many units of data will read from the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTES example : 1M | 512kB
 
 Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
@@ -113,7 +113,7 @@ Flags:
   -h, --help                help for write
   -p, --path string         'path' specifies the location to fill data in.If path not provided, payload will write into a temp file, temp file will be deleted after writing
   -n, --process-num uint8   'process-num' specifies the number of process work on writing , default 1, only 1-255 is valid value (default 1)
-  -s, --size string         'size' specifies how many units of data will write into the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTESexample : 1M | 512kB
+  -s, --size string         'size' specifies how many units of data will write into the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTES example : 1M | 512kB
 
 Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
@@ -170,7 +170,7 @@ Flags:
   -h, --help             help for fill
   -p, --path string      'path' specifies the location to fill data in.If path not provided, a temp file will be generated and deleted immediately after data filled in or allocated
   -c, --percent string   'percent' how many percent data of disk will fill in the file path
-  -s, --size string      'size' specifies how many units of data will fill in the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTESexample : 1M | 512kB
+  -s, --size string      'size' specifies how many units of data will fill in the file path.'unit' specifies the unit of data, support c=1, w=2, b=512, kB=1000, K=1024, MB=1000*1000,M=1024*1024, , GB=1000*1000*1000, G=1024*1024*1024 BYTES example : 1M | 512kB
 
 Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'

--- a/versioned_docs/version-2.0.0/simulate-heavy-stress-in-physical-nodes.md
+++ b/versioned_docs/version-2.0.0/simulate-heavy-stress-in-physical-nodes.md
@@ -9,7 +9,7 @@ This document describes how to use Chaosd to simulate stress scenarios. This fea
 
 This section describes how to create stress experiments in command-line mode.
 
-Before creating stress experiments, you can run the following command to view the stress experiment types supported by Chaosd：
+Before creating stress experiments, you can run the following command to view the stress experiment types supported by Chaosd:
 
 ```bash
 chaosd attack stress --help
@@ -68,7 +68,7 @@ Global Flags:
 
 #### Configuration description of simulating CPU stress
 
-| Configuration item | Abbreviation | Descpription                                                                                           | Value                                    |
+| Configuration item | Abbreviation | Description                                                                                            | Value                                    |
 | :----------------- | :----------- | :----------------------------------------------------------------------------------------------------- | :--------------------------------------- |
 | load               | l            | Specifies the percentage of CPU load per CPU worker. 0 means no CPU load, and 100 means full CPU load. | int; range: 0 to 100; default value: 10. |
 | workers            | w            | Specifies the number of workers used to create CPU stress.                                             | int; default value: 1.                   |
@@ -138,7 +138,7 @@ The result is as follows:
 Attack stress mem successfully, uid: c2bff2f5-3aac-4ace-b7a6-322946ae6f13
 ```
 
-When running the experiment, you need to save the uid information of the experiment. When a stress simulation is not needed, you can use `recover` to terminate the uid-related experiment:：
+When running the experiment, you need to save the uid information of the experiment. When a stress simulation is not needed, you can use `recover` to terminate the uid-related experiment::
 
 ```bash
 chaosd recover c2bff2f5-3aac-4ace-b7a6-322946ae6f13

--- a/versioned_docs/version-2.0.0/simulate-heavy-stress-on-kubernetes.md
+++ b/versioned_docs/version-2.0.0/simulate-heavy-stress-on-kubernetes.md
@@ -5,7 +5,7 @@ sidebar_label: Simulate Stress Scenarios
 
 ## StressChaos Introduction
 
-Chaos Mesh provides StresChaos experiments to simulate stress scenarios inside containers. This document describes how to create StressChaos experiments and how to prepare the corresponding configuration file.
+Chaos Mesh provides StressChaos experiments to simulate stress scenarios inside containers. This document describes how to create StressChaos experiments and how to prepare the corresponding configuration file.
 
 You can create experiments using either Chaos Dashboard or the YAML configuration files.
 
@@ -62,7 +62,7 @@ The fields in the YAML configuration file are described in the following table:
 | ----------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- | ----------- |
 | duration          | string                  | Specifies the duration of the experiment.                                                                                                                                                                                                                                                                                                                                   | None          | Yes      | `30s`       |
 | stressors         | [Stressors](#stressors) | Specifies the stress of CPU or memory                                                                                                                                                                                                                                                                                                                                       | None          | No       |             |
-| stressngStressors | string                  | Specifies the stres-ng parameter to reach richer stress injection                                                                                                                                                                                                                                                                                                           | None          | No       | `--clone 2` |
+| stressngStressors | string                  | Specifies the stress-ng parameter to reach richer stress injection                                                                                                                                                                                                                                                                                                           | None          | No       | `--clone 2` |
 | mode              | string                  | Specifies the mode of the experiment. The mode options include `one` (selecting a random Pod), `all` (selecting all eligible Pods), `fixed` (selecting a specified number of eligible Pods), `fixed-percent` (selecting a specified percentage of Pods from the eligible Pods), and `random-max-percent` (selecting the maximum percentage of Pods from the eligible Pods). | None          | Yes      | `1`         |
 | value             | string                  | Provides a parameter for the `mode` configuration, depending on `mode`.For example, when `mode` is set to `fixed-percent`, `value` specifies the percentage of Pods.                                                                                                                                                                                                        | None          | No       | `2`         |
 | containerNames    | []string                | Specifies the name of the container into which the fault is injected.                                                                                                                                                                                                                                                                                                       | None          | No       | `["nginx"]` |
@@ -84,7 +84,7 @@ The fields in the YAML configuration file are described in the following table:
 
 ##### CPUStressor
 
-| Parameter | Type | Descpription                                                                           | Default value | Required | Example |
+| Parameter | Type | Description                                                                           | Default value | Required | Example |
 | --------- | ---- | -------------------------------------------------------------------------------------- | ------------- | -------- | ------- |
 | workers   | int  | Specifies the number of threads that apply memory stress                               |               | Yes      | `1`     |
 | load      | int  | Specifies the percentage of CPU occupied0 means sleep and no load; 100 means full load |               | No       | `50`    |

--- a/versioned_docs/version-2.0.0/simulate-http-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.0.0/simulate-http-chaos-on-kubernetes.md
@@ -16,7 +16,7 @@ HTTPChaos is a fault type provided by Chaos Mesh. By creating HTTPChaos experime
 
 HTTPChaos supports combinations of different fault types. If you have configured multiple HTTP fault types at the same time when creating HTTPChaos experiments, the order set to inject the faults when the experiments start running is `abort` -> `delay` -> `replace` -> `patch`. When the `abort` fault cause short circuits, the connection will be directly interrupted.
 
-For the detailed description of HTTPChaos configuration, see [Field description](#Field-description) below.
+For the detailed description of HTTPChaos configuration, see [Field description](#field-description) below.
 
 ## Notes
 
@@ -28,11 +28,11 @@ Before injecting the faults supported by HTTPChaos, note the followings:
 
 ## Create experiments
 
-Currently, Chaos Mesh only supports using YAML configuration files to create HTTPChaos experiments. In the YAML files, you can simulate either one HTTP fault type or a comination of different HTTP fault types.
+Currently, Chaos Mesh only supports using YAML configuration files to create HTTPChaos experiments. In the YAML files, you can simulate either one HTTP fault type or a communication of different HTTP fault types.
 
 ### Example of `abort`
 
-1. Write the experimental configuration to the `http-abort-failure.yaml` file as the example below：
+1. Write the experimental configuration to the `http-abort-failure.yaml` file as the example below:
 
 ```yaml
 apiVersion: chaos-mesh.org/v1alpha1
@@ -64,7 +64,7 @@ kubectl apply -f ./http-abort-failure.yaml
 
 ### Example of fault combinations
 
-1. Write the experimental configuration to `http-failure.yaml` file as the example below：
+1. Write the experimental configuration to `http-failure.yaml` file as the example below:
 
 ```yaml
 apiVersion: chaos-mesh.org/v1alpha1
@@ -108,13 +108,13 @@ kubectl apply -f ./http-failure.yaml
 
 ### Description for common fields
 
-Common fields are meaningful when the `target` of fault injuection is `Request` or `Response`.
+Common fields are meaningful when the `target` of fault injection is `Request` or `Response`.
 
-| Parameter        | Type              | Descpription                                                                                                                                                                                                                                                                                                                                                                | Default value                             | Required | Example                        |
+| Parameter        | Type              | Description                                                                                                                                                                                                                                                                                                                                                                | Default value                             | Required | Example                        |
 | ---------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------- | ------------------------------ |
 | mode             | string            | Specifies the mode of the experiment. The mode options include `one` (selecting a random pod), `all` (selecting all eligible pods), `fixed` (selecting a specified number of eligible pods), `fixed-percent` (selecting a specified percentage of Pods from the eligible pods), and `random-max-percent` (selecting the maximum percentage of Pods from the eligible pods). |                                           | yes      | one                            |
 | value            | string            | Provides parameters for the `mode` configuration depending on the value of `mode`.                                                                                                                                                                                                                                                                                          |                                           | no       | 2                              |
-| target           | string            | Specifies whether the target of fault injuection is `Request` or `Response`. The [`target`-related fields](#Description-for-`target`-related-fields) should be configured at the same time.                                                                                                                                                                                 |                                           | yes      | Request                        |
+| target           | string            | Specifies whether the target of fault injection is `Request` or `Response`. The [`target`-related fields](#Description-for-`target`-related-fields) should be configured at the same time.                                                                                                                                                                                 |                                           | yes      | Request                        |
 | port             | int32             | The TCP port that the target service listens on.                                                                                                                                                                                                                                                                                                                            |                                           | yes      | 80                             |
 | method           | string            | The HTTP method of the target request method.                                                                                                                                                                                                                                                                                                                               | Takes effect for all methods by default.  | no       | GET                            |
 | path             | string            | The URI path of the target request which supports [Matching wildcards](https://www.wikiwand.com/en/Matching_wildcards).                                                                                                                                                                                                                                                     | Takes effect on all paths by default.     | no       | /api/\*                        |

--- a/versioned_docs/version-2.0.0/simulate-io-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.0.0/simulate-io-chaos-on-kubernetes.md
@@ -9,12 +9,12 @@ This document describes how to create IOChaos experiments in Chaos Mesh.
 
 IOChaos is a type of fault in Chaos Mesh. By creating an IOChaos experiment, you can simulate a scenario of file system fault. Currently, IOChaos supports the following fault types:
 
-- latency: delays file system calls
-- fault: returns an error for filesystem calls
-- attrOverride: modifies file properties
-- mistake: makes the file read or write a wrong value
+- `latency`: delays file system calls
+- `fault`: returns an error for filesystem calls
+- `attrOverride`: modifies file properties
+- `mistake`: makes the file read or write a wrong value
 
-For specific features, refer to [Create experiments using the YAML files](#create-experiments-using-the-yaml-file).
+For specific features, refer to [Create experiments using the YAML files](#create-experiments-using-the-yaml-files).
 
 ## Notes
 
@@ -141,20 +141,20 @@ kubectl apply -f ./io-attr.yaml
 ```yaml
 apiVersion: chaos-mesh. rg/v1alpha1
 ind: IOChaos
-metaada:
+metadata:
   name: io-mistake-example
   namespace: chaos-testing
 special:
   action: mistake
   mode: one
   selector:
-    labelselectors:
+    labelSelectors:
       app: etcd
   volumePath: /var/run/etcd
   path: /var/run/etcd/**/*
   mistake:
     filling: zero
-    maxOccarences: 1
+    maxOccurrences: 1
     maxLength: 10
   methods:
     - READ

--- a/versioned_docs/version-2.0.0/simulate-network-chaos-in-physical-nodes.md
+++ b/versioned_docs/version-2.0.0/simulate-network-chaos-in-physical-nodes.md
@@ -75,7 +75,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -119,7 +119,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -128,8 +128,8 @@ The related configuration items are described as follows：
 | egress-port        | e            | The egress traffic which only impact specific destination ports. It can only be configured when the protocol is TCP or UDP. | String. You need to use a ',' to separate the specific port or to indicate the range of the port, such as "80,8001:8010". |
 | hostname           | H            | The host name impacted by traffic.                                                                                          | String, such as "chaos-mesh.org".                                                                                         |
 | ip                 | i            | The IP address impacted by egress traffic.                                                                                  | String, such as "123.123.123.123".                                                                                        |
-| jitter             | j            | Range of the length of network delay time.                                                                                  | String. The time units can be：ns, us (µs), ms, s, m, h, such as "1ms".                                                   |
-| latency            | l            | Length of network delay time.                                                                                               | String. The time units can be：ns, us (μs), ms, s, m, h, such as "1ms".                                                   |
+| jitter             | j            | Range of the length of network delay time.                                                                                  | String. The time units can be: ns, us (µs), ms, s, m, h, such as "1ms".                                                   |
+| latency            | l            | Length of network delay time.                                                                                               | String. The time units can be: ns, us (μs), ms, s, m, h, such as "1ms".                                                   |
 | protocol           | p            | The IP protocol impacted by traffic.                                                                                        | String. It supports the following protocol types: tcp, udp, icmp, all (all network protocols).                            |
 | source-port        | s            | The egress traffic that only impacts specified source ports. It can only be configured when the protocol is TCP or UDP.     | String. You need to use a ',' to separate the specific port or to indicate the range of the port, such as "80,8001:8010". |
 
@@ -164,7 +164,7 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
 | Configuration item | Abbreviation | Description                                                                                                                  | Value                                                                                                                     |
 | :----------------- | :----------- | :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
@@ -208,9 +208,9 @@ Global Flags:
       --log-level string   the log level of chaosd, the value can be 'debug', 'info', 'warn' and 'error'
 ```
 
-The related configuration items are described as follows：
+The related configuration items are described as follows:
 
-| Configuration item | Abbreviation | Descpription                                                                                                                 | Value                                                                                                                     |
+| Configuration item | Abbreviation | Description                                                                                                                 | Value                                                                                                                     |
 | :----------------- | :----------- | :--------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
 | correlation        | c            | The correlation between the percentage of the current network loss and the previous one.                                     | Int. It is a percentage which range is 0 to 100 (10 is 10%) (default "0").                                                |
 | device             | d            | Name of the impacted network interface card.                                                                                 | String, such as “eth0”. The value is required.                                                                            |
@@ -223,7 +223,7 @@ The related configuration items are described as follows：
 
 ### Examples
 
-Simulate network corruption：
+Simulate network corruption:
 
 ```bash
 chaosd attack network corrupt -d eth0 -i 172.16.4.4 --percent 50
@@ -235,7 +235,7 @@ The output is as follows:
 Attack network successfully, uid: 4eab1e62-8d60-45cb-ac85-3c17b8ac4825
 ```
 
-Simulate network latency：
+Simulate network latency:
 
 ```bash
 chaosd attack network delay -d eth0 -i 172.16.4.4 -l 10ms
@@ -247,7 +247,7 @@ The output is as follows:
 Attack network successfully, uid: 4b23a0b5-e193-4b27-90a7-3e04235f32ab
 ```
 
-Simulate network duplication：
+Simulate network duplication:
 
 ```bash
 chaosd attack network duplicate -d eth0 -i 172.16.4.4 --percent 50
@@ -259,7 +259,7 @@ The output is as follows:
 Attack network successfully, uid: 7bcb74ee-9101-4ae4-82f0-e44c8a7f113c
 ```
 
-Simulate network loss：
+Simulate network loss:
 
 ```bash
 chaosd attack network loss -d eth0 -i 172.16.4.4 --percent 50
@@ -271,7 +271,7 @@ The output is as follows:
 Attack network successfully, uid: 1e818adf-3942-4de4-949b-c8499f120265
 ```
 
-When running the experiments, remember to save the uid of the experiments. To end a network fault simulation, use `recover`：
+When running the experiments, remember to save the uid of the experiments. To end a network fault simulation, use `recover`:
 
 ```bash
 chaosd recover 1e818adf-3942-4de4-949b-c8499f120265

--- a/versioned_docs/version-2.0.0/simulate-network-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.0.0/simulate-network-chaos-on-kubernetes.md
@@ -9,7 +9,7 @@ This document describes how to simulate network faults using NetworkChaos in Cha
 
 NetworkChaos is a fault type in Chaos Mesh. By creating a NetworkChaos experiment, you can simulate a network fault scenario for a cluster. Currently, NetworkChaos supports the following fault types:
 
-- **Partition**：network disconnection and partition.
+- **Partition**: network disconnection and partition.
 - **Net Emulation**: poor network conditions, such as high delays, high packet loss rate, packet reordering, and so on.
 - **Bandwidth**: limit the communication bandwidth between nodes.
 
@@ -63,7 +63,7 @@ Before creating NetworkChaos experiments, ensure the following:
        jitter: '0ms'
    ```
 
-This configuration causes a latency of 10 milliseconds in the network connections of the target Pods. In addition to latency injection, Chaos Mesh supports packet loss and packet reordering injection. For details, see [field description](#字段说明).
+This configuration causes a latency of 10 milliseconds in the network connections of the target Pods. In addition to latency injection, Chaos Mesh supports packet loss and packet reordering injection. For details, see [field description](#field-description).
 
 2. After the configuration file is prepared, use `kubectl` to create an experiment:
 

--- a/versioned_docs/version-2.0.0/simulate-pod-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.0.0/simulate-pod-chaos-on-kubernetes.md
@@ -9,13 +9,13 @@ This document describes how to use Chaos Mesh to inject faults into Kubernetes P
 
 PodChaos is a fault type in Chaos Mesh. By creating a PodChaos experiment, you can simulate fault scenarios of the specified Pods or containers. Currently, PodChaos supports the following fault types:
 
-- Pod Failure: injects fault into a specified Pod to make the Pod unavailable for a period of time.
-- Pod Kill: kills a specified Pod.To ensure that the Pod can be successfully restarted, you need to configure ReplicaSet or similar mechanisms.
-- Container Kill: kills the specified container in the target Pod.
+- **Pod Failure**: injects fault into a specified Pod to make the Pod unavailable for a period of time.
+- **Pod Kill**: kills a specified Pod.To ensure that the Pod can be successfully restarted, you need to configure ReplicaSet or similar mechanisms.
+- **Container Kill**: kills the specified container in the target Pod.
 
 ## Usage restrictions
 
-Currently, Chaos Mesh only supports fault injection to certain types of Pod, such as Deployment, Statefulset, and Daemonset. Chaos Mesh does not support injecting faults into an independent Pod. An independent Pod means a Pod that is not bound to ReplicaSet or Deployment Pod.
+Currently, Chaos Mesh only supports fault injection to certain types of Pod, such as Deployment, StatefulSet, and DaemonSet. Chaos Mesh does not support injecting faults into an independent Pod. An independent Pod means a Pod that is not bound to ReplicaSet or Deployment Pod.
 
 ## Notes
 

--- a/versioned_docs/version-2.0.0/simulate-process-chaos-in-physical-nodes.md
+++ b/versioned_docs/version-2.0.0/simulate-process-chaos-in-physical-nodes.md
@@ -3,7 +3,7 @@ title: Simulate Process Faults
 sidebar_label: Simulate Process Faults
 ---
 
-This document describes how to use Chaosd to simulate process faults. The process faults use the Golang interface of the kill command to simulate the scenarios that the process is killed or stoped. You can create experiments either in command-line mode or service mode.
+This document describes how to use Chaosd to simulate process faults. The process faults use the Golang interface of the kill command to simulate the scenarios that the process is killed or stopped. You can create experiments either in command-line mode or service mode.
 
 ## Create experiments in command-line mode
 
@@ -13,7 +13,7 @@ Before creating an experiment, you can run the following command to see the proc
 chaosd attack process -h
 ```
 
-The output is as follows：
+The output is as follows:
 
 ```bash
 Process attack related commands
@@ -44,7 +44,7 @@ Currently, Chaosd supports simulating that a process is killed or stopped.
 chaosd attack process kill -h
 ```
 
-The output is as follows：
+The output is as follows:
 
 ```bash
 kill process, default signal 9
@@ -63,7 +63,7 @@ Global Flags:
 
 #### Configuration description of simulating a process being killed
 
-| Configuration item | Abbreviation | Descpription                                                  | Value                                                                                     |
+| Configuration item | Abbreviation | Description                                                  | Value                                                                                     |
 | :----------------- | :----------- | :------------------------------------------------------------ | :---------------------------------------------------------------------------------------- |
 | process            | p            | The name or identifier of the process that needs to be killed | string; the default value is "".                                                          |
 | signal             | s            | The provided value of the process signal                      | int; the default value is 9. Currently, only SIGKILL, SIGTERM, and SIGSTOP are supported. |


### PR DESCRIPTION
* Updated documentation and blog post with correct terminology (daemonset -> DaemonSet, etc)
* Fixed some set of tpyos (Descpription -> Description, etc)
* Fix typos in k8s object specification (labelselectors -> labelSelectors)
* Replaced Chinese character ： for latin :
* Made more consistent formatting around types of actions:
  * if action is a technical keyword like latency it's formatted as `latency`, if fault type is a general terminology it's formatted in bold **Pod Failure**
* Fixed a few broken links - link in md need to be in lower case, having `YAML` in a link doesn't create HTML anchor, it needs to be `yaml`

I made two commits with the same changes, one commit affects versioned documentation for 2.0.0 and another commit is general for non-versioned docs, for something I assume is a template for future releases.