### PR TITLE
add version to helm install / helm upgrade

### DIFF
--- a/docs/add-new-chaos-experiment-type.md
+++ b/docs/add-new-chaos-experiment-type.md
@@ -3,6 +3,8 @@ title: Add New Chaos Experiment Type
 sidebar_label: Add New Chaos Experiment Type
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to add a new chaos experiment type.
 
 The following walks you through an example of HelloWorldChaos, a new chaos experiment type that prints `Hello World!` to the log. The steps include:
@@ -259,9 +261,7 @@ After you update the template, try running HelloWorldChaos.
 
 2. Deploy Chaos Mesh:
 
-   ```bash
-   helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-   ```
+   <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --version latest`}</PickHelmVersion>
 
    To verify the deployment is successful, you can check all Pods in the `chaos-testing` namespace:
 

--- a/docs/configure-enabled-namespace.md
+++ b/docs/configure-enabled-namespace.md
@@ -3,6 +3,8 @@ title: Configure namespace for Chaos experiments
 sidebar_label: Configure namespace for Chaos experiments
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This chapter walks you through how to configure Chaos experiments to only take effect in the specified namespace, and protect other unspecified namespaces against fault injection.
 
 ## Control the scope where the Chaos experiment takes effect
@@ -16,9 +18,7 @@ Chaos Mesh offers two ways to control the scope of the Chaos experiment to take 
 
 If you have not installed Chaos Mesh yet, you can enable this feature during installation by adding `--set controllerManager.enableFilterNamespace=true` to the command when installing using Helm. The following is a command example in the Docker container:
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set controllerManager.enableFilterNamespace=true
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set controllerManager.enableFilterNamespace=true --version latest`}</PickHelmVersion>
 
 :::note
 
@@ -28,9 +28,7 @@ When you use Helm for installation, commands and parameters differ for different
 
 If you have installed Chaos Mesh using Helm, you can enable this feature by upgrading the configuration with the `helm upgrade` command. For example:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set controllerManager.enableFilterNamespace=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --version latest --set controllerManager.enableFilterNamespace=true`}</PickHelmVersion>
 
 For `helm upgrade`, you can set multiple parameters by adding multiple `--set` in the command. Later settings override previous settings. For example, if you add `--set controllerManager.enableFilterNamespace=false -set controllerManager.enableFilterNamespace=true` in the command, it still enables this feature.
 

--- a/docs/extend-chaos-daemon-interface.md
+++ b/docs/extend-chaos-daemon-interface.md
@@ -203,9 +203,7 @@ To verify the experiment, perform the following steps.
 
 2. Update Chaos Mesh:
 
-   ```bash
-   helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing
-   ```
+   <PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
 3. Deploy the target Pod for testing. Skip this step if you have already deployed this Pod:
 

--- a/docs/extend-chaos-daemon-interface.md
+++ b/docs/extend-chaos-daemon-interface.md
@@ -3,6 +3,8 @@ title: Extend Chaos Daemon Interface
 sidebar_label: Extend Chaos Daemon Interface
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 In [Add new chaos experiment type](add-new-chaos-experiment-type.md), you have added HelloWorldChaos, which can print `Hello World!` in the logs of Chaos Controller Manager. To enable the HelloWorldChaos to inject some faults into the target Pod, you need to extend interface for Chaos Daemon.
 
 :::note

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -18,9 +18,7 @@ No. Instead, you could use [`chaosd`](https://github.com/chaos-mesh/chaosd/) to 
 
 You can use the `hostNetwork` parameter to fix this issue as follows:
 
-```
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set chaosDaemon.hostNetwork=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --version latest --set chaosDaemon.hostNetwork=true`}</PickHelmVersion>
 
 ### Q: The default administrator Google Cloud user account is forbidden to create chaos experiments. How to fix it?
 
@@ -32,13 +30,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-cluster-manager-pdmas
 rules:
-- apiGroups: [""]
-  resources: ["pods", "namespaces"]
-  verbs: ["get", "watch", "list"]
-- apiGroups:
-  - chaos-mesh.org
-  resources: [ "*" ]
-  verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: ['']
+    resources: ['pods', 'namespaces']
+    verbs: ['get', 'watch', 'list']
+  - apiGroups:
+      - chaos-mesh.org
+    resources: ['*']
+    verbs: ['get', 'list', 'watch', 'create', 'delete', 'patch', 'update']
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,9 +44,9 @@ metadata:
   name: cluster-manager-binding
   namespace: chaos-testing
 subjects:
-# Google Cloud user account
-- kind: User
-  name: USER_ACCOUNT
+  # Google Cloud user account
+  - kind: User
+    name: USER_ACCOUNT
 roleRef:
   kind: ClusterRole
   name: role-cluster-manager-pdmas
@@ -97,4 +95,3 @@ You need to add privileged scc to default.
 ```bash
 oc adm policy add-scc-to-user privileged -n chaos-testing -z chaos-daemon
 ```
-

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -4,6 +4,8 @@ title: FAQs
 sidebar_label: FAQs
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 ## Questions
 
 ### Q: If I do not have deployed Kubernetes clusters, can I use Chaos Mesh to create chaos experiments?

--- a/docs/manage-user-permissions.md
+++ b/docs/manage-user-permissions.md
@@ -141,8 +141,6 @@ In the right part of this page, you can add new tokens in the **Add token** wind
 
 If Chaos Mesh is installed using Helm, the permission authentication feature is enabled by default.For production environments and other scenarios with high security requirements, it is recommended to keep the permission authentication feature enabled.If you just want to give Chaos Mesh a try and quickly create Chaos experiments with the permission authentication feature disabled, you can set `--set dashboard.securityMode=false` in a Helm command. The command is as follows:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.securityMode=false`}</PickHelmVersion>
 
 If you want to enable the permission authentication feature again, then reset `--set dashboard.securityMode=true` in a Helm command.

--- a/docs/manage-user-permissions.md
+++ b/docs/manage-user-permissions.md
@@ -2,6 +2,8 @@
 title: Manage User Permissions
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to manage user permissions in Chaos Mesh, including creating user account of different roles, binding permissions for users, managing tokens, and enable or disable permission authentication.
 
 Chaos Mesh uses the native [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) features in Kubernetes to manage user roles and permissions. To create, view and manage Chaos experiments, users need to have the corresponding permissions in the `apiGroups` of `chaos-mesh.org` to customize resources of Chaos experiments.

--- a/docs/offline-installation.md
+++ b/docs/offline-installation.md
@@ -4,6 +4,7 @@ sidebar_label: Install Chaos Mesh Offline
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 import VerifyInstallation from './common/verify-installation.md'
 import QuickRun from './common/quick-run.md'
@@ -141,12 +142,7 @@ kubectl create ns chaos-testing
 
 Execute the installation command. When executing the installation command, you need to specify the namespace of Chaos Mesh and the image value of each component:
 
-```bash
-helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \
-  --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \
-  --set controllerManager.image=$CHAOS_MESH_IMAGE \
-  --set dashboard.image=$CHAOS_DASHBOARD_IMAGE
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --version latest`}</PickHelmVersion>
 
 ## Verify the installation
 

--- a/docs/offline-installation.md
+++ b/docs/offline-installation.md
@@ -142,7 +142,12 @@ kubectl create ns chaos-testing
 
 Execute the installation command. When executing the installation command, you need to specify the namespace of Chaos Mesh and the image value of each component:
 
-<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --version latest`}</PickHelmVersion>
+<PickHelmVersion className="language-bash">{`
+helm install chaos-mesh helm/chaos-mesh -n=chaos-testing
+    --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE
+    --set controllerManager.image=$CHAOS_MESH_IMAGE
+    --set dashboard.image=$CHAOS_DASHBOARD_IMAGE
+    --version latest`}</PickHelmVersion>
 
 ## Verify the installation
 

--- a/docs/production-installation-using-helm.md
+++ b/docs/production-installation-using-helm.md
@@ -79,11 +79,8 @@ Because socket paths are listened to by the daemons of different running contain
 
 #### Docker
 
-<PickHelmVersion className="language-bash">
-\# Default to /var/run/docker.sock
-
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest
-</PickHelmVersion>
+<PickHelmVersion className="language-bash">{`\# Default to /var/run/docker.sock
+helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest`}</PickHelmVersion>
 
 #### Containerd
 

--- a/docs/production-installation-using-helm.md
+++ b/docs/production-installation-using-helm.md
@@ -4,6 +4,7 @@ sidebar_label: Install Chaos Mesh using Helm
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 import VerifyInstallation from './common/verify-installation.md'
 import QuickRun from './common/quick-run.md'
@@ -78,22 +79,19 @@ Because socket paths are listened to by the daemons of different running contain
 
 #### Docker
 
-```bash
-# Default to /var/run/docker.sock
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing
-```
+<PickHelmVersion className="language-bash">
+\# Default to /var/run/docker.sock
+
+helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest
+</PickHelmVersion>
 
 #### Containerd
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --version latest`}</PickHelmVersion>
 
 #### K3s
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock --version latest`}</PickHelmVersion>
 
 :::note
 
@@ -131,9 +129,7 @@ If you have upgraded Chaos Mesh in a non-Docker environment, you need to add the
 
 To modify the configuration, set different values according to your need. For example, execute the following command to upgrade and uninstall `chaos-dashboard`:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set dashboard.create=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest --set dashboard.create=false`}</PickHelmVersion>
 
 :::note
 
@@ -177,6 +173,4 @@ helm install chaos-mesh helm/chaos-mesh -n=chaos-teting
 
 The safe mode is enabled by default. To disable the safe mode, specify `dashboard.securityMode` as `false` during the installation or upgrade:
 
-```bash
-helm install chaos-mesh helm/chaos-mesh -n=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing --set dashboard.securityMode=false --version latest`}</PickHelmVersion>

--- a/docs/simulate-dns-chaos-on-kubernetes.md
+++ b/docs/simulate-dns-chaos-on-kubernetes.md
@@ -13,9 +13,7 @@ DNSChaos is used to simulate wrong DNS responses. For example, DNSChaos can retu
 
 Before creating a DNSChaos experiment using Chaos Mesh, you need to deploy a special DNS service to inject faults:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dnsServer.create=true`}</PickHelmVersion>
 
 After executing the above commands, check if the DNS service status is normal:
 

--- a/docs/simulate-dns-chaos-on-kubernetes.md
+++ b/docs/simulate-dns-chaos-on-kubernetes.md
@@ -3,6 +3,8 @@ title: Simulate DNS Faults
 sidebar_label: Simulate DNS Faults
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to create DNSChaos experiments in Chaos Mesh to simulate DNS faults.
 
 ## DNSChaos Introduction

--- a/src/components/PickHelmVersion.jsx
+++ b/src/components/PickHelmVersion.jsx
@@ -1,0 +1,35 @@
+import BrowserOnly from '@docusaurus/BrowserOnly'
+import CodeBlock from '../theme/CodeBlock'
+import React from 'react'
+import { usePickVersion } from './PickVersion'
+
+const PickHelmVersion = ({ children, className }) => {
+  const Result = ({ children }) => (
+    <div style={{ marginBottom: '1.25rem' }}>
+      <CodeBlock className={className}>{children}</CodeBlock>
+    </div>
+  )
+
+  const calcHelmChartVersion = version => {
+      if (version[0] === '2') {
+          return version
+      }
+
+      const startPart = version.slice(0, 3)
+      const helmChartVersionStartPart = (parseFloat(startPart) - 0.7).toString()
+      return helmChartVersionStartPart + version.slice(3)
+  }
+
+  return (
+    <BrowserOnly fallback={<Result>{children}</Result>}>
+      {() => {
+        const version = usePickVersion()
+        const realVersion = version === 'latest' ? "" : `--version v${calcHelmChartVersion(version)}`
+
+        return <Result>{children.replace('--version latest', realVersion).trim()}</Result>
+      }}
+    </BrowserOnly>
+  )
+}
+
+export default PickHelmVersion

--- a/versioned_docs/version-0.9.1/development_guides/dev_hello_world.md
+++ b/versioned_docs/version-0.9.1/development_guides/dev_hello_world.md
@@ -4,13 +4,16 @@ title: Develop a New Chaos
 sidebar_label: Develop a New Chaos
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 After [preparing the development environment](setup_env.md), let's develop a new type of chaos, HelloWorldChaos, which only prints a "Hello World!" message to the log. Generally, to add a new chaos type for Chaos Mesh, you need to take the following steps:
 
-1. [Add the chaos object in controller](#add-the-chaos-object-in-controller)
-2. [Register the CRD](#register-the-crd)
-3. [Implement the schema type](#implement-the-schema-type)
-4. [Make the Docker image](#make-the-docker-image)
-5. [Run chaos](#run-chaos)
+- [Add the chaos object in controller](#add-the-chaos-object-in-controller)
+- [Register the CRD](#register-the-crd)
+- [Implement the schema type](#implement-the-schema-type)
+- [Make the Docker image](#make-the-docker-image)
+- [Run chaos](#run-chaos)
+- [Next steps](#next-steps)
 
 ## Add the chaos object in controller
 
@@ -191,10 +194,7 @@ Now take the following steps to run chaos:
 
 2. Install Chaos Mesh:
 
-   ```bash
-   helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-   kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
-   ```
+   <PickHelmVersion className="language-bash">{`helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --version latest kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh`}</PickHelmVersion>
 
    The arguments `--set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock` is used to to support network chaos on kind.
 

--- a/versioned_docs/version-0.9.1/installation/installation.md
+++ b/versioned_docs/version-0.9.1/installation/installation.md
@@ -105,13 +105,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - For helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1
      ```
 
      - For helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -144,13 +144,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -183,13 +183,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:

--- a/versioned_docs/version-0.9.1/installation/installation.md
+++ b/versioned_docs/version-0.9.1/installation/installation.md
@@ -4,6 +4,7 @@ title: Installation
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 This document describes how to install Chaos Mesh to perform chaos experiments against your application in Kubernetes.
 
@@ -104,15 +105,15 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - For helm 2.X
 
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
+
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1
+
      ```
 
      - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -143,15 +144,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -182,15 +179,15 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
+
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+
      ```
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-0.9.1/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-0.9.1/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.2.1 --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-1.0.3/development_guides/dev_hello_world.md
+++ b/versioned_docs/version-1.0.3/development_guides/dev_hello_world.md
@@ -4,13 +4,16 @@ title: Develop a New Chaos
 sidebar_label: Develop a New Chaos
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 After [preparing the development environment](setup_env.md), let's develop a new type of chaos, HelloWorldChaos, which only prints a "Hello World!" message to the log. Generally, to add a new chaos type for Chaos Mesh, you need to take the following steps:
 
-1. [Define the schema type](#define-the-schema-type)
-2. [Register the CRD](#register-the-crd)
-3. [Register the handler for this chaos object](#register-the-handler-for-this-chaos-object)
-4. [Make the Docker image](#make-the-docker-image)
-5. [Run chaos](#run-chaos)
+- [Define the schema type](#define-the-schema-type)
+- [Register the CRD](#register-the-crd)
+- [Register the handler for this chaos object](#register-the-handler-for-this-chaos-object)
+- [Make the Docker image](#make-the-docker-image)
+- [Run chaos](#run-chaos)
+- [Next steps](#next-steps)
 
 ## Define the schema type
 
@@ -214,15 +217,11 @@ Now take the following steps to run chaos:
 
    - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --version latest`}</PickHelmVersion>
 
    - For helm 2.X
 
-     ```bash
-     helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --version latest`}</PickHelmVersion>
 
    To verify your installation, get pods from the `chaos-testing` namespace:
 

--- a/versioned_docs/version-1.0.3/user_guides/installation.md
+++ b/versioned_docs/version-1.0.3/user_guides/installation.md
@@ -4,6 +4,7 @@ title: Installation
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 This document describes how to install Chaos Mesh to perform chaos experiments against your application in Kubernetes.
 
@@ -114,15 +115,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - For helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
      - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -153,15 +150,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -192,15 +185,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-1.0.3/user_guides/installation.md
+++ b/versioned_docs/version-1.0.3/user_guides/installation.md
@@ -115,13 +115,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - For helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3
      ```
 
      - For helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -154,13 +154,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -193,13 +193,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:

--- a/versioned_docs/version-1.0.3/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-1.0.3/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.3.3 --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-1.1.4/chaos_experiments/dns_chaos.md
+++ b/versioned_docs/version-1.1.4/chaos_experiments/dns_chaos.md
@@ -4,6 +4,8 @@ title: DNSChaos Experiment
 sidebar_label: DNSChaos Experiment
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to create DNSChaos experiments in Chaos Mesh.
 
 DNSChaos allows you to simulate fault DNS responses such as a DNS error or a random IP address after a request is sent.

--- a/versioned_docs/version-1.1.4/chaos_experiments/dns_chaos.md
+++ b/versioned_docs/version-1.1.4/chaos_experiments/dns_chaos.md
@@ -12,9 +12,7 @@ DNSChaos allows you to simulate fault DNS responses such as a DNS error or a ran
 
 To create DNSChaos experiments in Chaos Mesh, you need to deploy a DNS service in Chaos Mesh by executing the command below:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dnsServer.create=true`}</PickHelmVersion>
 
 When the deployment finishes, check the status of this DNS service:
 

--- a/versioned_docs/version-1.1.4/development_guides/dev_hello_world.md
+++ b/versioned_docs/version-1.1.4/development_guides/dev_hello_world.md
@@ -4,13 +4,16 @@ title: Develop a New Chaos
 sidebar_label: Develop a New Chaos
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 After [preparing the development environment](setup_env.md), let's develop a new type of chaos, HelloWorldChaos, which only prints a "Hello World!" message to the log. Generally, to add a new chaos type for Chaos Mesh, you need to take the following steps:
 
-1. [Define the schema type](#define-the-schema-type)
-2. [Register the CRD](#register-the-crd)
-3. [Register the handler for this chaos object](#register-the-handler-for-this-chaos-object)
-4. [Make the Docker image](#make-the-docker-image)
-5. [Run chaos](#run-chaos)
+- [Define the schema type](#define-the-schema-type)
+- [Register the CRD](#register-the-crd)
+- [Register the handler for this chaos object](#register-the-handler-for-this-chaos-object)
+- [Make the Docker image](#make-the-docker-image)
+- [Run chaos](#run-chaos)
+- [Next steps](#next-steps)
 
 ## Define the schema type
 
@@ -214,15 +217,11 @@ Now take the following steps to run chaos:
 
    - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
    - For helm 2.X
 
-     ```bash
-     helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
    To verify your installation, get pods from the `chaos-testing` namespace:
 

--- a/versioned_docs/version-1.1.4/user_guides/dashboard.md
+++ b/versioned_docs/version-1.1.4/user_guides/dashboard.md
@@ -10,13 +10,13 @@ Chaos Dashboard is a one-step web UI for managing, designing, and monitoring cha
 You can install Chaos Mesh with Chaos Dashboard by executing the command below:
 
 ```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true
+helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set dashboard.create=true
 ```
 
 If you have already installed Chaos Mesh, upgrade it by executing:
 
 ```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true
+helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set dashboard.create=true
 ```
 
 ## Enable/Disable security mode

--- a/versioned_docs/version-1.1.4/user_guides/dashboard.md
+++ b/versioned_docs/version-1.1.4/user_guides/dashboard.md
@@ -3,21 +3,19 @@ id: dashboard
 title: Chaos Dashboard
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 Chaos Dashboard is a one-step web UI for managing, designing, and monitoring chaos experiments on Chaos Mesh. This document provides a step-by-step introduction on how to use Chaos Dashboard.
 
 ## Install Chaos Dashboard
 
 You can install Chaos Mesh with Chaos Dashboard by executing the command below:
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set dashboard.create=true
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.create=true`}</PickHelmVersion>
 
 If you have already installed Chaos Mesh, upgrade it by executing:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set dashboard.create=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.create=true`}</PickHelmVersion>
 
 ## Enable/Disable security mode
 
@@ -25,9 +23,7 @@ Chaos Dashboard supports a security mode, which requires users to login with a t
 
 The security mode is enabled by default if you install via Helm. You can disable it by executing:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.securityMode=false`}</PickHelmVersion>
 
 **Note:**
 

--- a/versioned_docs/version-1.1.4/user_guides/installation.md
+++ b/versioned_docs/version-1.1.4/user_guides/installation.md
@@ -4,6 +4,7 @@ title: Installation
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 This document describes how to install Chaos Mesh to perform chaos experiments against your application in Kubernetes.
 
@@ -114,15 +115,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - For helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
      - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -153,15 +150,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -192,15 +185,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-1.1.4/user_guides/installation.md
+++ b/versioned_docs/version-1.1.4/user_guides/installation.md
@@ -115,13 +115,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - For helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4
      ```
 
      - For helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -154,13 +154,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -193,13 +193,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:

--- a/versioned_docs/version-1.1.4/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-1.1.4/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.4.4 --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-1.2.3/chaos_experiments/dns_chaos.md
+++ b/versioned_docs/version-1.2.3/chaos_experiments/dns_chaos.md
@@ -4,6 +4,8 @@ title: DNSChaos Experiment
 sidebar_label: DNSChaos Experiment
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to create DNSChaos experiments in Chaos Mesh.
 
 DNSChaos allows you to simulate fault DNS responses such as a DNS error or a random IP address after a request is sent.

--- a/versioned_docs/version-1.2.3/chaos_experiments/dns_chaos.md
+++ b/versioned_docs/version-1.2.3/chaos_experiments/dns_chaos.md
@@ -12,9 +12,7 @@ DNSChaos allows you to simulate fault DNS responses such as a DNS error or a ran
 
 To create DNSChaos experiments in Chaos Mesh, you need to deploy a DNS service in Chaos Mesh by executing the command below:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dnsServer.create=true`}</PickHelmVersion>
 
 When the deployment finishes, check the status of this DNS service:
 

--- a/versioned_docs/version-1.2.3/development_guides/dev_hello_world.md
+++ b/versioned_docs/version-1.2.3/development_guides/dev_hello_world.md
@@ -4,6 +4,8 @@ title: Develop a New Chaos
 sidebar_label: Develop a New Chaos
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 After [preparing the development environment](setup_env.md), let's develop a new type of chaos, HelloWorldChaos, which only prints a "Hello World!" message to the log. Generally, to add a new chaos type for Chaos Mesh, you need to take the following steps:
 
 1. [Define the schema type](#define-the-schema-type)
@@ -214,15 +216,11 @@ Now take the following steps to run chaos:
 
    - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
    - For helm 2.X
 
-     ```bash
-     helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
    To verify your installation, get pods from the `chaos-testing` namespace:
 

--- a/versioned_docs/version-1.2.3/user_guides/dashboard.md
+++ b/versioned_docs/version-1.2.3/user_guides/dashboard.md
@@ -3,6 +3,8 @@ id: dashboard
 title: Chaos Dashboard
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 Chaos Dashboard is a one-step web UI for managing, designing, and monitoring chaos experiments on Chaos Mesh. This document provides a step-by-step introduction on how to use Chaos Dashboard.
 
 ## Install Chaos Dashboard

--- a/versioned_docs/version-1.2.3/user_guides/dashboard.md
+++ b/versioned_docs/version-1.2.3/user_guides/dashboard.md
@@ -22,9 +22,7 @@ chaos-dashboard-b8767fbcd-46cnd   1/1     Running   0          31m
 
 If you don't get the Chaos Dashboard pod, you can add it by executing:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.create=true`}</PickHelmVersion>
 
 ## Enable/Disable security mode
 
@@ -32,9 +30,7 @@ Chaos Dashboard supports a security mode, which requires users to login with a t
 
 The security mode is enabled by default if you install via Helm. You can disable it by executing:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.securityMode=false`}</PickHelmVersion>
 
 **Note:**
 

--- a/versioned_docs/version-1.2.3/user_guides/installation.md
+++ b/versioned_docs/version-1.2.3/user_guides/installation.md
@@ -97,13 +97,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - For helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3
      ```
 
      - For helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -136,13 +136,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:
@@ -175,13 +175,13 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
      - for helm 2.X
 
      ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
      - for helm 3.X
 
      ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
+     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
      ```
 
   3. Check whether Chaos Mesh pods are installed:

--- a/versioned_docs/version-1.2.3/user_guides/installation.md
+++ b/versioned_docs/version-1.2.3/user_guides/installation.md
@@ -4,6 +4,7 @@ title: Installation
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 This document describes how to install Chaos Mesh to perform chaos experiments against your application in Kubernetes.
 
@@ -96,15 +97,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - For helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
      - For helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -135,15 +132,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 
@@ -174,15 +167,11 @@ Depending on your environment, there are two methods of installing Chaos Mesh:
 
      - for helm 2.X
 
-     ```bash
-     helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
      - for helm 3.X
 
-     ```bash
-     helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3 --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-     ```
+     <PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
   3. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-1.2.3/user_guides/offline_installation.md
+++ b/versioned_docs/version-1.2.3/user_guides/offline_installation.md
@@ -3,6 +3,8 @@ id: offline_installation
 title: Offline Installation
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to install Chaos Mesh in an offline environment.
 
 ## Prerequisites
@@ -158,15 +160,7 @@ Now that you already have the image and repo archive files in the offline enviro
 
    c. Install Chaos Mesh by helm:
 
-   ```bash
-   helm install chaos-mesh helm/chaos-mesh  --namespace=chaos-testing \
-      --set dashboard.create=true \
-      --set dnsServer.create=true \
-      --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \
-      --set controllerManager.image=$CHAOS_MESH_IMAGE \
-      --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \
-      --set dnsServer.image=${CHAOS_COREDNS_IMAGE}
-   ```
+   <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing \ --set dashboard.create=true \ --set dnsServer.create=true \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --set dnsServer.image=${CHAOS_COREDNS_IMAGE} \ --version latest`}</PickHelmVersion>
 
    d. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-1.2.3/user_guides/offline_installation.md
+++ b/versioned_docs/version-1.2.3/user_guides/offline_installation.md
@@ -160,7 +160,15 @@ Now that you already have the image and repo archive files in the offline enviro
 
    c. Install Chaos Mesh by helm:
 
-   <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing \ --set dashboard.create=true \ --set dnsServer.create=true \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --set dnsServer.image=${CHAOS_COREDNS_IMAGE} \ --version latest`}</PickHelmVersion>
+   <PickHelmVersion className="language-bash">{`
+   helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing
+      --set dashboard.create=true
+      --set dnsServer.create=true
+      --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE
+      --set controllerManager.image=$CHAOS_MESH_IMAGE
+      --set dashboard.image=$CHAOS_DASHBOARD_IMAGE
+      --set dnsServer.image=$CHAOS_COREDNS_IMAGE
+      --version latest`}</PickHelmVersion>
 
    d. Check whether Chaos Mesh pods are installed:
 

--- a/versioned_docs/version-1.2.3/user_guides/run_chaos_experiment.md
+++ b/versioned_docs/version-1.2.3/user_guides/run_chaos_experiment.md
@@ -102,7 +102,7 @@ Chaos Dashboard is a Web UI for managing, designing, monitoring Chaos Experiment
 
 > **Note:**
 >
-> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=true`.
+> If Chaos Dashboard was not installed, upgrade Chaos Mesh by executing `helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version v0.5.3 --set dashboard.create=true`.
 
 A typical way to access it is to use `kubectl port-forward`:
 

--- a/versioned_docs/version-2.0.1/add-new-chaos-experiment-type.md
+++ b/versioned_docs/version-2.0.1/add-new-chaos-experiment-type.md
@@ -3,6 +3,8 @@ title: Add New Chaos Experiment Type
 sidebar_label: Add New Chaos Experiment Type
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to add a new chaos experiment type.
 
 The following walks you through an example of HelloWorldChaos, a new chaos experiment type that prints `Hello World!` to the log. The steps include:
@@ -259,9 +261,7 @@ After you update the template, try running HelloWorldChaos.
 
 2. Deploy Chaos Mesh:
 
-   ```bash
-   helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-   ```
+   <PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
    To verify the deployment is successful, you can check all Pods in the `chaos-testing` namespace:
 

--- a/versioned_docs/version-2.0.1/configure-enabled-namespace.md
+++ b/versioned_docs/version-2.0.1/configure-enabled-namespace.md
@@ -3,6 +3,8 @@ title: Configure namespace for Chaos experiments
 sidebar_label: Configure namespace for Chaos experiments
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This chapter walks you through how to configure Chaos experiments to only take effect in the specified namespace, and protect other unspecified namespaces against fault injection.
 
 ## Control the scope where the Chaos experiment takes effect
@@ -16,9 +18,7 @@ Chaos Mesh offers two ways to control the scope of the Chaos experiment to take 
 
 If you have not installed Chaos Mesh yet, you can enable this feature during installation by adding `--set controllerManager.enableFilterNamespace=true` to the command when installing using Helm. The following is a command example in the Docker container:
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set controllerManager.enableFilterNamespace=true
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --version latest --set controllerManager.enableFilterNamespace=true`}</PickHelmVersion>
 
 :::note
 
@@ -28,9 +28,7 @@ When you use Helm for installation, commands and parameters differ for different
 
 If you have installed Chaos Mesh using Helm, you can enable this feature by upgrading the configuration with the `helm upgrade` command. For example:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set controllerManager.enableFilterNamespace=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --version latest --set controllerManager.enableFilterNamespace=true`}</PickHelmVersion>
 
 For `helm upgrade`, you can set multiple parameters by adding multiple `--set` in the command. Later settings override previous settings. For example, if you add `--set controllerManager.enableFilterNamespace=false -set controllerManager.enableFilterNamespace=true` in the command, it still enables this feature.
 

--- a/versioned_docs/version-2.0.1/extend-chaos-daemon-interface.md
+++ b/versioned_docs/version-2.0.1/extend-chaos-daemon-interface.md
@@ -3,6 +3,8 @@ title: Extend Chaos Daemon Interface
 sidebar_label: Extend Chaos Daemon Interface
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 In [Add new chaos experiment type](add-new-chaos-experiment-type.md), you have added HelloWorldChaos, which can print `Hello World!` in the logs of Chaos Controller Manager. To enable the HelloWorldChaos to inject some faults into the target Pod, you need to extend interface for Chaos Daemon.
 
 :::note

--- a/versioned_docs/version-2.0.1/extend-chaos-daemon-interface.md
+++ b/versioned_docs/version-2.0.1/extend-chaos-daemon-interface.md
@@ -14,6 +14,7 @@ This document covers:
 - [Selector](#selector)
 - [Implement the gRPC interface](#implement-the-grpc-interface)
 - [Verify the experiment](#verify-the-experiment)
+- [Next steps](#next-steps)
 
 ## Selector
 
@@ -203,9 +204,7 @@ To verify the experiment, perform the following steps.
 
 2. Update Chaos Mesh:
 
-   ```bash
-   helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing
-   ```
+   <PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh helm/chaos-mesh --namespace=chaos-testing --version latest`}</PickHelmVersion>
 
 3. Deploy the target Pod for testing. Skip this step if you have already deployed this Pod:
 

--- a/versioned_docs/version-2.0.1/faqs.md
+++ b/versioned_docs/version-2.0.1/faqs.md
@@ -18,9 +18,7 @@ No. Instead, you could use [`chaosd`](https://github.com/chaos-mesh/chaosd/) to 
 
 You can use the `hostNetwork` parameter to fix this issue as follows:
 
-```
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --set chaosDaemon.hostNetwork=true
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n chaos-testing --version latest --set chaosDaemon.hostNetwork=true`}</PickHelmVersion>
 
 ### Q: The default administrator Google Cloud user account is forbidden to create chaos experiments. How to fix it?
 
@@ -32,13 +30,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-cluster-manager-pdmas
 rules:
-- apiGroups: [""]
-  resources: ["pods", "namespaces"]
-  verbs: ["get", "watch", "list"]
-- apiGroups:
-  - chaos-mesh.org
-  resources: [ "*" ]
-  verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: ['']
+    resources: ['pods', 'namespaces']
+    verbs: ['get', 'watch', 'list']
+  - apiGroups:
+      - chaos-mesh.org
+    resources: ['*']
+    verbs: ['get', 'list', 'watch', 'create', 'delete', 'patch', 'update']
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,9 +44,9 @@ metadata:
   name: cluster-manager-binding
   namespace: chaos-testing
 subjects:
-# Google Cloud user account
-- kind: User
-  name: USER_ACCOUNT
+  # Google Cloud user account
+  - kind: User
+    name: USER_ACCOUNT
 roleRef:
   kind: ClusterRole
   name: role-cluster-manager-pdmas
@@ -97,4 +95,3 @@ You need to add privileged scc to default.
 ```bash
 oc adm policy add-scc-to-user privileged -n chaos-testing -z chaos-daemon
 ```
-

--- a/versioned_docs/version-2.0.1/faqs.md
+++ b/versioned_docs/version-2.0.1/faqs.md
@@ -4,6 +4,8 @@ title: FAQs
 sidebar_label: FAQs
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 ## Questions
 
 ### Q: If I do not have deployed Kubernetes clusters, can I use Chaos Mesh to create chaos experiments?

--- a/versioned_docs/version-2.0.1/manage-user-permissions.md
+++ b/versioned_docs/version-2.0.1/manage-user-permissions.md
@@ -141,8 +141,6 @@ In the right part of this page, you can add new tokens in the **Add token** wind
 
 If Chaos Mesh is installed using Helm, the permission authentication feature is enabled by default.For production environments and other scenarios with high security requirements, it is recommended to keep the permission authentication feature enabled.If you just want to give Chaos Mesh a try and quickly create Chaos experiments with the permission authentication feature disabled, you can set `--set dashboard.securityMode=false` in a Helm command. The command is as follows:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dashboard.securityMode=false`}</PickHelmVersion>
 
 If you want to enable the permission authentication feature again, then reset `--set dashboard.securityMode=true` in a Helm command.

--- a/versioned_docs/version-2.0.1/manage-user-permissions.md
+++ b/versioned_docs/version-2.0.1/manage-user-permissions.md
@@ -2,6 +2,8 @@
 title: Manage User Permissions
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to manage user permissions in Chaos Mesh, including creating user account of different roles, binding permissions for users, managing tokens, and enable or disable permission authentication.
 
 Chaos Mesh uses the native [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) features in Kubernetes to manage user roles and permissions. To create, view and manage Chaos experiments, users need to have the corresponding permissions in the `apiGroups` of `chaos-mesh.org` to customize resources of Chaos experiments.

--- a/versioned_docs/version-2.0.1/offline-installation.md
+++ b/versioned_docs/version-2.0.1/offline-installation.md
@@ -4,6 +4,7 @@ sidebar_label: Install Chaos Mesh Offline
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 import VerifyInstallation from './common/verify-installation.md'
 import QuickRun from './common/quick-run.md'
@@ -141,12 +142,7 @@ kubectl create ns chaos-testing
 
 Execute the installation command. When executing the installation command, you need to specify the namespace of Chaos Mesh and the image value of each component:
 
-```bash
-helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \
-  --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \
-  --set controllerManager.image=$CHAOS_MESH_IMAGE \
-  --set dashboard.image=$CHAOS_DASHBOARD_IMAGE
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --version latest`}</PickHelmVersion>
 
 ## Verify the installation
 

--- a/versioned_docs/version-2.0.1/offline-installation.md
+++ b/versioned_docs/version-2.0.1/offline-installation.md
@@ -142,7 +142,12 @@ kubectl create ns chaos-testing
 
 Execute the installation command. When executing the installation command, you need to specify the namespace of Chaos Mesh and the image value of each component:
 
-<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing \ --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE \ --set controllerManager.image=$CHAOS_MESH_IMAGE \ --set dashboard.image=$CHAOS_DASHBOARD_IMAGE \ --version latest`}</PickHelmVersion>
+<PickHelmVersion className="language-bash">{`
+helm install chaos-mesh helm/chaos-mesh -n=chaos-testing
+    --set chaosDaemon.image=$CHAOS_DAEMON_IMAGE
+    --set controllerManager.image=$CHAOS_MESH_IMAGE
+    --set dashboard.image=$CHAOS_DASHBOARD_IMAGE
+    --version latest`}</PickHelmVersion>
 
 ## Verify the installation
 

--- a/versioned_docs/version-2.0.1/production-installation-using-helm.md
+++ b/versioned_docs/version-2.0.1/production-installation-using-helm.md
@@ -80,7 +80,7 @@ Because socket paths are listened to by the daemons of different running contain
 
 ```bash
 # Default to /var/run/docker.sock
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing
+helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version v2.0.1
 ```
 
 #### Containerd

--- a/versioned_docs/version-2.0.1/production-installation-using-helm.md
+++ b/versioned_docs/version-2.0.1/production-installation-using-helm.md
@@ -79,11 +79,8 @@ Because socket paths are listened to by the daemons of different running contain
 
 #### Docker
 
-<PickHelmVersion className="language-bash">
-\# Default to /var/run/docker.sock
-
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest
-</PickHelmVersion>
+<PickHelmVersion className="language-bash">{`\# Default to /var/run/docker.sock
+helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest`}</PickHelmVersion>
 
 #### Containerd
 

--- a/versioned_docs/version-2.0.1/production-installation-using-helm.md
+++ b/versioned_docs/version-2.0.1/production-installation-using-helm.md
@@ -4,6 +4,7 @@ sidebar_label: Install Chaos Mesh using Helm
 ---
 
 import PickVersion from '@site/src/components/PickVersion'
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
 
 import VerifyInstallation from './common/verify-installation.md'
 import QuickRun from './common/quick-run.md'
@@ -78,22 +79,19 @@ Because socket paths are listened to by the daemons of different running contain
 
 #### Docker
 
-```bash
-# Default to /var/run/docker.sock
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version v2.0.1
-```
+<PickHelmVersion className="language-bash">
+\# Default to /var/run/docker.sock
+
+helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest
+</PickHelmVersion>
 
 #### Containerd
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock`}</PickHelmVersion>
 
 #### K3s
 
-```bash
-helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/k3s/containerd/containerd.sock`}</PickHelmVersion>
 
 :::note
 
@@ -113,15 +111,7 @@ To install Chaos Mesh of a specific version, add the `--version xxx` parameter a
 
 To upgrade Chaos Mesh, execute the following command:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh
-```
-
-:::note
-
-To upgrade Chaos Mesh to a specific version, add the `--version xxx` parameter after `helm upgrade`, for example, `--version 2.0.0`.
-
-:::
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh --version latest`}</PickHelmVersion>
 
 :::note
 
@@ -131,9 +121,7 @@ If you have upgraded Chaos Mesh in a non-Docker environment, you need to add the
 
 To modify the configuration, set different values according to your need. For example, execute the following command to upgrade and uninstall `chaos-dashboard`:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set dashboard.create=false
-```
+<PickHelmVersion className="language-bash">{`helm upgrade chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --version latest --set dashboard.create=false`}</PickHelmVersion>
 
 :::note
 
@@ -177,6 +165,4 @@ helm install chaos-mesh helm/chaos-mesh -n=chaos-teting
 
 The safe mode is enabled by default. To disable the safe mode, specify `dashboard.securityMode` as `false` during the installation or upgrade:
 
-```bash
-helm install chaos-mesh helm/chaos-mesh -n=chaos-testing --set dashboard.securityMode=false
-```
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing --version latest --set dashboard.securityMode=false`}</PickHelmVersion>

--- a/versioned_docs/version-2.0.1/simulate-dns-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.0.1/simulate-dns-chaos-on-kubernetes.md
@@ -3,6 +3,8 @@ title: Simulate DNS Faults
 sidebar_label: Simulate DNS Faults
 ---
 
+import PickHelmVersion from '@site/src/components/PickHelmVersion'
+
 This document describes how to create DNSChaos experiments in Chaos Mesh to simulate DNS faults.
 
 ## DNSChaos Introduction
@@ -13,9 +15,12 @@ DNSChaos is used to simulate wrong DNS responses. For example, DNSChaos can retu
 
 Before creating a DNSChaos experiment using Chaos Mesh, you need to deploy a special DNS service to inject faults:
 
-```bash
-helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dnsServer.create=true
-```
+<PickVersion className="language-bash">
+export CHAOS_MESH_VERSION=latest
+</PickVersion>
+<PickHelmVersion className="language-bash">{`
+helm upgrade chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --version latest --set dnsServer.create=true
+`}</PickHelmVersion>
 
 After executing the above commands, check if the DNS service status is normal:
 


### PR DESCRIPTION
Some user of Chaos Mesh reports that the installation guide of Chaos Mesh doesn't contain the version parameter, so that following the v1.2.1 installation guide, they will install the latest (v2.0.1) version.

In this PR, a new React Component ("PickHelmVersion") is introduced to automatically set version parameter for helm command.