### PR TITLE
fix(docs): incorrect command to download charts

### DIFF
--- a/docs/offline-installation.md
+++ b/docs/offline-installation.md
@@ -58,7 +58,7 @@ To simulate a DNS fault (for example, make the DNS responses return a random wro
 On the machine connected to the external network, download the zip package of Chaos Mesh:
 
 ```bash
-curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip -o chaos-mesh.zip
+curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip
 ```
 
 ### Copy files


### PR DESCRIPTION
### Motivation

The command of `curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip -o chaos-mesh.zip` will get a zip file which cannot be unziped. 

The correct command should be `curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip`.