### PR TITLE
fix(docs): incorrect command to download charts

### DIFF
--- a/docs/offline-installation.md
+++ b/docs/offline-installation.md
@@ -58,7 +58,7 @@ To simulate a DNS fault (for example, make the DNS responses return a random wro
 On the machine connected to the external network, download the zip package of Chaos Mesh:
 
 ```bash
-curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip -o chaos-mesh.zip
+curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip
 ```
 
 ### Copy files

--- a/i18n/zh/docusaurus-plugin-content-docs/current/offline-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/offline-installation.md
@@ -57,7 +57,7 @@ docker save pingcap/chaos-dashboard:${CHAOS_MESH_VERSION} > image-chaos-dashboar
 在有外网连接的机器上，下载 Chaos Mesh 的 zip 包：
 
 ```bash
-curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip -o chaos-mesh.zip
+curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip
 ```
 
 ### 拷贝文件

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.0.4/offline-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.0.4/offline-installation.md
@@ -57,7 +57,7 @@ docker save pingcap/chaos-dashboard:${CHAOS_MESH_VERSION} > image-chaos-dashboar
 在有外网连接的机器上，下载 Chaos Mesh 的 zip 包：
 
 <PickVersion>
-curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/tags/latest.zip -o chaos-mesh.zip
+curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/tags/latest.zip
 </PickVersion>
 
 ### 拷贝文件

--- a/versioned_docs/version-2.0.4/offline-installation.md
+++ b/versioned_docs/version-2.0.4/offline-installation.md
@@ -58,7 +58,7 @@ To simulate a DNS fault (for example, make the DNS responses return a random wro
 On the machine connected to the external network, download the zip package of Chaos Mesh:
 
 <PickVersion>
-curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/tags/latest.zip -o chaos-mesh.zip
+curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/tags/latest.zip
 </PickVersion>
 
 ### Copy files


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

### Motivation

The command of `curl https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip -o chaos-mesh.zip` will get a zip file which cannot be unziped. 

The correct command should be `curl -fsSL -o chaos-mesh.zip https://github.com/chaos-mesh/chaos-mesh/archive/refs/heads/master.zip`.