### PR TITLE
Typo in helm chart repo link fix

### DIFF
--- a/versioned_docs/version-2.1.3/production-installation-using-helm.md
+++ b/versioned_docs/version-2.1.3/production-installation-using-helm.md
@@ -189,4 +189,4 @@ helm install chaos-mesh helm/chaos-mesh -n=chaos-testing
 
 The safe mode is enabled by default. To disable the safe mode, specify `dashboard.securityMode` as `false` during the installation or upgrade:
 
-<PickHelmVersion className="language-bash">{`helm install chaos-mesh helm/chaos-mesh -n=chaos-testing --set dashboard.securityMode=false --version latest`}</PickHelmVersion>
+<PickHelmVersion className="language-bash">{`helm install chaos-mesh chaos-mesh/chaos-mesh -n=chaos-testing --set dashboard.securityMode=false --version latest`}</PickHelmVersion>


### PR DESCRIPTION
I believe i found a typo in the documentation when i was working on my own project
Let me know if i'm wrong - i will delete the PR