### PR TITLE
fix: JS float pitfall

### DIFF
--- a/src/components/PickHelmVersion.jsx
+++ b/src/components/PickHelmVersion.jsx
@@ -14,7 +14,7 @@ const calcHelmChartVersion = (version) => {
   const startPart = version.slice(0, 3)
   const helmChartVersionStartPart = parseFloat(startPart) - 0.7
 
-  return 'v' + helmChartVersionStartPart + version.slice(3)
+  return 'v' + helmChartVersionStartPart.toFixed(1) + version.slice(3)
 }
 
 const PickHelmVersion = ({ children, className = 'language-bash' }) => {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com> 

Fix JS float pitfall. This issue will cause that helm version to show a wrong value, like:  
![middle_img_v2_ef67312f-1d9f-4354-bed9-13b156a4389g](https://user-images.githubusercontent.com/22956341/153750511-135233e3-3bc4-46d1-a848-0f542d6ea8f7.png)

Fixed: 
![image](https://user-images.githubusercontent.com/22956341/153750534-de10ad0e-daa1-4fb5-aa94-4042d9b8b5a1.png)

**PS: This pr is not the best solution for JS float pitfall, but it works well here.**