### PR TITLE
Remove Vector WASM Transform link

### DIFF
--- a/blog/2021-06-25-chaos-mesh-remake-one-step-closer-toward-chaos-as-a-service.md
+++ b/blog/2021-06-25-chaos-mesh-remake-one-step-closer-toward-chaos-as-a-service.md
@@ -134,7 +134,7 @@ To enable full plugin support, we need to explore a new method to add plugins. A
 
 - Develop a controller or operator to manage CRDs.
 - Handle CRD events uniformly and operate on CRDs via HTTP callback. This method only uses HTTP APIs, with no requirement on Golang. For an example, see [Whitebox Controller](https://github.com/summerwind/whitebox-controller).
-- Use WebAssembly (Wasm). When you need to call chaos experiment logic, just call the Wasm program. See Vector's [WASM Transform](https://webcache.googleusercontent.com/search?q=cache:aR1ZIlTwz9sJ:https://vector.dev/docs/reference/configuration/transforms/wasm/+&cd=2&hl=zh-CN&ct=clnk&gl=jp).
+- Use WebAssembly (Wasm). When you need to call chaos experiment logic, just call the Wasm program.
 - Use SQL to query the chaos experiment status. Because Chaos Mesh is based on CRDs, you can use SQL to operate on Kubernetes. Examples include [Presto connector](https://github.com/xuxinkun/kubesql) and [osquery extension](https://github.com/aquasecurity/kube-query).
 - Use SDK-based extensions, such as [Chaos Toolkit](https://docs.chaostoolkit.org/reference/api/experiment/).
 


### PR DESCRIPTION
Signed-off-by: Aolin Zhang <aolin.zhang@pingcap.com>

Close: https://github.com/chaos-mesh/website/issues/290

Remove WASM link because [wasm transform to be removed from Vector](https://vector.dev/highlights/2021-08-23-removing-wasm/)