### PR TITLE
fix: correct IOChaos containerNames

### DIFF
--- a/versioned_docs/version-2.2.0/simulate-io-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.2.0/simulate-io-chaos-on-kubernetes.md
@@ -184,7 +184,7 @@ For specific features, refer to [Create experiments using the YAML files](#creat
 | path | string | The valid range of fault injections, either a wildcard or a single file. | Valid for all files by default | No | /var/run/etcd/\*_/_ |
 | methods | string[] | Type of the file system call that requires injecting fault. For more information about supported types, refer to [Appendix A](#appendix-a: methods-type). | All Types | No | READ |
 | percent | int | Probability of failure per operation, in %. | 100 | No | 100 |
-| ContainerName | string | Specifies the name of the container into which the fault is injected. |  | No |  |
+| containerNames | []string | Specifies the name of the container into which the fault is injected. |  | No |  |
 | duration | string | Specifies the duration of the experiment. |  | Yes | 30s |
 
 #### Fields related to action


### PR DESCRIPTION
General fields ContainerName should be containerNames, and type is  []string