### PR TITLE
Correct namespace in Quick Start

### DIFF
--- a/docs/common/verify-installation.md
+++ b/docs/common/verify-installation.md
@@ -1,7 +1,7 @@
 To check the running status of Chaos Mesh, execute the following command:
 
 ```sh
-kubectl get po -n chaos-testing
+kubectl get po -n chaos-mesh
 ```
 
 The expected output is as follows:
@@ -21,7 +21,7 @@ If the `STATUS` of your actual output is not `Running`, then execute the followi
 
 ```sh
 # Take the chaos-controller as an example
-kubectl describe po -n chaos-testing chaos-controller-manager-69fd5c46c8-xlqpc
+kubectl describe po -n chaos-mesh chaos-controller-manager-69fd5c46c8-xlqpc
 ```
 
 :::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/common/verify-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/common/verify-installation.md
@@ -1,7 +1,7 @@
 要查看 Chaos Mesh 的运行情况，请执行以下命令：
 
 ```bash
-kubectl get po -n chaos-testing
+kubectl get po -n chaos-mesh
 ```
 
 以下是预期输出：
@@ -21,7 +21,7 @@ chaos-dashboard-98c4c5f97-tx5ds             1/1     Running   0          2d5h
 
 ```bash
 # 以 chaos-controller 为例
-kubectl describe po -n chaos-testing chaos-controller-manager-69fd5c46c8-xlqpc
+kubectl describe po -n chaos-mesh chaos-controller-manager-69fd5c46c8-xlqpc
 ```
 
 :::

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.3.1/common/verify-installation.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.3.1/common/verify-installation.md
@@ -1,7 +1,7 @@
 要查看 Chaos Mesh 的运行情况，请执行以下命令：
 
 ```bash
-kubectl get po -n chaos-testing
+kubectl get po -n chaos-mesh
 ```
 
 以下是预期输出：
@@ -21,7 +21,7 @@ chaos-dashboard-98c4c5f97-tx5ds             1/1     Running   0          2d5h
 
 ```bash
 # 以 chaos-controller 为例
-kubectl describe po -n chaos-testing chaos-controller-manager-69fd5c46c8-xlqpc
+kubectl describe po -n chaos-mesh chaos-controller-manager-69fd5c46c8-xlqpc
 ```
 
 :::

--- a/versioned_docs/version-2.3.1/common/verify-installation.md
+++ b/versioned_docs/version-2.3.1/common/verify-installation.md
@@ -1,7 +1,7 @@
 To check the running status of Chaos Mesh, execute the following command:
 
 ```sh
-kubectl get po -n chaos-testing
+kubectl get po -n chaos-mesh
 ```
 
 The expected output is as follows:
@@ -21,7 +21,7 @@ If the `STATUS` of your actual output is not `Running`, then execute the followi
 
 ```sh
 # Take the chaos-controller as an example
-kubectl describe po -n chaos-testing chaos-controller-manager-69fd5c46c8-xlqpc
+kubectl describe po -n chaos-mesh chaos-controller-manager-69fd5c46c8-xlqpc
 ```
 
 :::


### PR DESCRIPTION
- Problem: namespace `chaos-testing` shown in "Quick Start" page does not exist in the specified version (`v2.3.1`) of Chaos Mesh
- Fix by this PR: the namespace is updated to `chaos-mesh`, the correct one

---
Signed-off-by: Akira Hayashi <smxshxishxad@me.com>
