### PR TITLE
Correct parameter type for Bandwidth limit

### DIFF
--- a/versioned_docs/version-2.5.0/simulate-network-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.5.0/simulate-network-chaos-on-kubernetes.md
@@ -231,7 +231,7 @@ Setting `action` to `bandwidth` means simulating bandwidth limit fault. You also
 | Parameter | Type | Description | Default value | Required | Example |
 | --- | --- | --- | --- | --- | --- |
 | rate | string | Indicates the rate of bandwidth limit |  | Yes | 1mbps |
-| limit | string | Indicates the number of bytes waiting in queue |  | Yes | 1 |
+| limit | int | Indicates the number of bytes waiting in queue |  | Yes | 1 |
 | buffer | uint32 | Indicates the maximum number of bytes that can be sent instantaneously |  | Yes | 1 |
 | peakrate | uint64 | Indicates the maximum consumption of `bucket` (usually not set) |  | No | 1 |
 | minburst | uint32 | Indicates the size of `peakrate bucket` (usually not set) |  | No | 1 |

--- a/versioned_docs/version-2.5.0/simulate-network-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.5.0/simulate-network-chaos-on-kubernetes.md
@@ -231,7 +231,7 @@ Setting `action` to `bandwidth` means simulating bandwidth limit fault. You also
 | Parameter | Type | Description | Default value | Required | Example |
 | --- | --- | --- | --- | --- | --- |
 | rate | string | Indicates the rate of bandwidth limit |  | Yes | 1mbps |
-| limit | int | Indicates the number of bytes waiting in queue |  | Yes | 1 |
+| limit | uint32 | Indicates the number of bytes waiting in queue |  | Yes | 1 |
 | buffer | uint32 | Indicates the maximum number of bytes that can be sent instantaneously |  | Yes | 1 |
 | peakrate | uint64 | Indicates the maximum consumption of `bucket` (usually not set) |  | No | 1 |
 | minburst | uint32 | Indicates the size of `peakrate bucket` (usually not set) |  | No | 1 |


### PR DESCRIPTION
Bandwidth limit string -> int.
Output from kubectl apply:
kubectl apply -f bandwidth.yaml
error: error validating "bandwidth.yaml": error validating data: ValidationError(NetworkChaos.spec.bandwidth.limit): invalid type for org.chaos-mesh.v1alpha1.NetworkChaos.spec.bandwidth.limit: got "string", expected "integer"; if you choose to ignore these errors, turn validation off with --validate=false