### PR TITLE
fix typos in iochaos example

### DIFF
--- a/docs/simulate-io-chaos-on-kubernetes.md
+++ b/docs/simulate-io-chaos-on-kubernetes.md
@@ -143,7 +143,7 @@ For specific features, refer to [Create experiments using the YAML files](#creat
    metadata:
      name: io-mistake-example
      namespace: chaos-mesh
-   secp:
+   spec:
      action: mistake
      mode: one
      selector:

--- a/docs/simulate-io-chaos-on-kubernetes.md
+++ b/docs/simulate-io-chaos-on-kubernetes.md
@@ -138,12 +138,12 @@ For specific features, refer to [Create experiments using the YAML files](#creat
 1. Write the experiment configuration to the `io-mistake.yaml` file:
 
    ```yaml
-   apiVersion: chaos-mesh. rg/v1alpha1
-   ind: IOChaos
+   apiVersion: chaos-mesh.org/v1alpha1
+   kind: IOChaos
    metadata:
      name: io-mistake-example
      namespace: chaos-mesh
-   special:
+   secp:
      action: mistake
      mode: one
      selector:


### PR DESCRIPTION
Fixed typos in the IOChaos mistake example