### PR TITLE
fix: title of Simulate HTTP faults

### DIFF
--- a/docs/simulate-http-chaos-on-kubernetes.md
+++ b/docs/simulate-http-chaos-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Simulate HTTP faults
+title: Simulate HTTP Faults
 ---
 
 This document describes how to simulate HTTP faults by creating HTTPChaos experiments in Chaos Mesh.

--- a/versioned_docs/version-2.4.3/simulate-http-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.4.3/simulate-http-chaos-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Simulate HTTP faults
+title: Simulate HTTP Faults
 ---
 
 This document describes how to simulate HTTP faults by creating HTTPChaos experiments in Chaos Mesh.

--- a/versioned_docs/version-2.5.2/simulate-http-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.5.2/simulate-http-chaos-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Simulate HTTP faults
+title: Simulate HTTP Faults
 ---
 
 This document describes how to simulate HTTP faults by creating HTTPChaos experiments in Chaos Mesh.

--- a/versioned_docs/version-2.6.2/simulate-http-chaos-on-kubernetes.md
+++ b/versioned_docs/version-2.6.2/simulate-http-chaos-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-title: Simulate HTTP faults
+title: Simulate HTTP Faults
 ---
 
 This document describes how to simulate HTTP faults by creating HTTPChaos experiments in Chaos Mesh.


### PR DESCRIPTION
fix typo, `Simulate HTTP faults` -> `Simulate HTTP Faults`