### PR TITLE
chore: update supported k8s versions

### DIFF
--- a/src/pages/supported-releases.md
+++ b/src/pages/supported-releases.md
@@ -6,7 +6,11 @@ This page lists the status, timeline and policies for currently supported releas
 
 ## TL;DR
 
-Each release is supported for a period of **six months**, and we create a new release **every three months**.
+~~Each release is supported for a period of **six months**, and we create a new release **every three months**.~~
+
+Update in 2024-02-01:
+
+As we currently haven't had enough maintainers to support the release cycle, We will release new versions from time to time, with a cycle of about **6 months**.
 
 :::
 
@@ -28,9 +32,15 @@ Support for kubernetes `1.22` is available starting with version `2.0.4`.
 
 :::
 
+:::info
+
+The `2.6` version also theoretically works fine on the `1.26`, `1.27`, and `1.28` versions of Kubernetes, but we do not sync the E2E tests for these versions.
+
+:::
+
 | Version | Currently Supported   | Release Date | End of Life  | Supported Kubernetes versions                  |
 | :------ | :-------------------- | :----------- | :----------- | :--------------------------------------------- |
-| master  | No, development only  | -            | -            | 1.20, 1.21, 1.22, 1.23, 1.24, 1.25             |
+| master  | No, development only  | -            | -            | 1.26, 1.27, 1.28                               |
 | 2.6     | `Yes`                 | May 31, 2023 | -            | 1.20, 1.21, 1.22, 1.23, 1.24, 1.25             |
 | 2.5     | `Yes`                 | Nov 22, 2022 | -            | 1.20, 1.21, 1.22, 1.23, 1.24, 1.25             |
 | 2.4     | No                    | Sep 23, 2022 | May 31, 2023 | 1.20, 1.21, 1.22, 1.23, 1.24, 1.25             |
@@ -73,7 +83,7 @@ Below are Kubernetes versions covered by each version of the E2E tests:
 
 | Version | Tested kubernetes Versions |
 | :------ | :------------------------- |
-| master  | 1.20, 1.23, 1.25           |
-| 2.6     | 1.20, 1.23, 1.25           |
+| master  | 1.26.13, 1.27.10, 1.28.6   |
+| 2.6     | 1.20.15, 1.23.4, 1.25.1    |
 | 2.5     | 1.20, 1.23, 1.25           |
 | 2.4     | 1.20, 1.23, 1.25           |


### PR DESCRIPTION
Follows https://github.com/chaos-mesh/chaos-mesh/pull/4319, updates the supported k8s versions.