### PR TITLE
Correct the container count

### DIFF
--- a/docs/common/_verify-installation.md
+++ b/docs/common/_verify-installation.md
@@ -8,7 +8,7 @@ The expected output is as follows:
 
 ```sh
 NAME                                        READY   STATUS    RESTARTS   AGE
-chaos-controller-manager-69fd5c46c8-xlqpc   3/3     Running   0          2d5h
+chaos-controller-manager-69fd5c46c8-xlqpc   1/1     Running   0          2d5h
 chaos-daemon-jb8xh                          1/1     Running   0          2d5h
 chaos-dashboard-98c4c5f97-tx5ds             1/1     Running   0          2d5h
 ```


### PR DESCRIPTION
In the documentation the installation mentions chaos-controller-manager container count as 3/3 which is incorrect. 

The pod only has 1 container. Ideally it should be 1/1